### PR TITLE
Improve docs for getLocale()

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1,5 +1,7 @@
 declare module "alt-client" {
   type StatName = "stamina" | "strength" | "lung_capacity" | "wheelie_ability" | "flying_ability" | "shooting_ability" | "stealth_ability";
+  type Locale = "ar" | "by" | "cz" | "de" | "en" | "es" | "fa" | "fr" | "he" | "hu" | "id" | "in_hd" | "in_ml" | "in_tl" | "in_tm" | "it"
+        | "lt" | "lv" | "nb_no" | "nn_no" | "pl" | "pt" | "pt_br" | "ro" | "rs" | "ru" | "sk" | "th" | "tr" | "ua" | "zh_cn" | "zh_tw";
 
   export interface DiscordOAuth2Token {
     readonly token: string
@@ -647,7 +649,7 @@ declare module "alt-client" {
    * 
    * @returns The language identifier (e.g. "en" for English)
    */
-  export function getLocale(): "de" | "en" | "fr" | "hu" | "ru" | string;
+  export function getLocale(): Locale;
 
   export function getMsPerGameMinute(): number;
 

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -640,7 +640,14 @@ declare module "alt-client" {
 
   export function getLicenseHash(): string;
 
-  export function getLocale(): string;
+  /**
+   * Returns the language identifier configured in alt:V / alt.cfg.
+   * All possible identifiers are listed here:
+   * https://github.com/altmp/altv-locales/tree/master/langs
+   * 
+   * @returns The language identifier (e.g. "en" for English)
+   */
+  export function getLocale(): "de" | "en" | "fr" | "hu" | "ru" | string;
 
   export function getMsPerGameMinute(): number;
 


### PR DESCRIPTION
I'm currently rewriting my gamemode for alt:V and found "getLocale".
But I couldn't find any information about the function except that it returns the language of your alt:V client.
I still didn't know if it e.g. returns "English", "en-US", "en", 1033 (Windows LCID), 9 (Microsoft Language Id), "eng" (Microsoft Language Code) etc.
So I had to test it to find out what it returns.

To prevent having to test it to find out what it returns, I've added the comment and also some possible return values (so the users exactly know what's returned).
The return type can be any of these examples ("de", "en" etc.) or another string.
For the examples I've just selected the languages I've seen in Discord at the admins names.