### PR TITLE
Fixes errors with setTimeout, setInterval, nextTick, everyTick

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1618,7 +1618,7 @@ declare module "alt-client" {
    * @param handler Handler that should be scheduled for execution.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearEveryTick} function to cancel the timer.
    */
-  export function everyTick(handler: () => void): number;
+  export function everyTick(handler: (...args: any[]) => void): number;
 
   /**
    * Returns whether the game controls are currently enabled.
@@ -1769,7 +1769,7 @@ declare module "alt-client" {
    * @param handler Handler that should be scheduled for execution.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearNextTick} function to cancel the timer.
    */
-  export function nextTick(handler: () => void): number;
+  export function nextTick(handler: (...args: any[]) => void): number;
 
   /**
    * Unsubscribes from client event with specified listener.
@@ -1928,7 +1928,7 @@ declare module "alt-client" {
    * @param miliseconds The time, in milliseconds, between execution of specified handler.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearInterval} function to cancel the timer.
    */
-  export function setInterval(handler: () => void, miliseconds: number): number;
+  export function setInterval(handler: (...args: any[]) => void, miliseconds: number): number;
 
   /**
    * Sets the amount of real milliseconds that have to pass every game minute.
@@ -1960,7 +1960,7 @@ declare module "alt-client" {
    * @param miliseconds The time, in milliseconds, before execution of specified handler.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearTimeout} function to cancel the timer.
    */
-  export function setTimeout(handler: () => void, miliseconds: number): number;
+  export function setTimeout(handler: (...args: any[]) => void, miliseconds: number): number;
 
   /**
    * Sets the current weather cycle.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1394,7 +1394,7 @@ declare module "alt-server" {
    * @param handler Handler that should be scheduled for execution.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearEveryTick} function to cancel the timer.
    */
-  export function everyTick(handler: () => void): number;
+  export function everyTick(handler: (...args: any[]) => void): number;
 
   /**
    * Gets the amount of milliseconds since the server was started.
@@ -1457,7 +1457,7 @@ declare module "alt-server" {
    * @param handler Handler that should be scheduled for execution.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearNextTick} function to cancel the timer.
    */
-  export function nextTick(handler: () => void): number;
+  export function nextTick(handler: (...args: any[]) => void): number;
 
   /**
    * Unsubscribes from server event with specified listener.
@@ -1532,7 +1532,7 @@ declare module "alt-server" {
    * @param miliseconds The time, in milliseconds, between execution of specified handler.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearInterval} function to cancel the timer.
    */
-  export function setInterval(handler: () => void, miliseconds: number): number;
+  export function setInterval(handler: (...args: any[]) => void, miliseconds: number): number;
 
   /**
    * Schedules execution of handler once after the expiration of interval.
@@ -1541,7 +1541,7 @@ declare module "alt-server" {
    * @param miliseconds The time, in milliseconds, before execution of specified handler.
    * @returns A number representing the id value of the timer that is set. Use this value with the {@link clearTimeout} function to cancel the timer.
    */
-  export function setTimeout(handler: () => void, miliseconds: number): number;
+  export function setTimeout(handler: (...args: any[]) => void, miliseconds: number): number;
 
   /**
    * Starts the specified resource.


### PR DESCRIPTION
Hi,

I fixed some weird kind of errors that should not exists in setTimeout, setInterval, nextTick, everyTick (before some more updates it worked fine, something changed in few months?) that can't pass any args in handlers (callbacks).

Code to debug it:
`return new Promise(resolve => alt.setTimeout(resolve, ms))`

Error:
`Argument of type '(value: unknown) => void' is not assignable to parameter of type '() => void'.`

With that debug code I'm unable to use "sleep" async function.