### PR TITLE
Add information about FE_THDR_GTAO

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1549,7 +1549,7 @@ declare module "alt-client" {
   export function hasSyncedMeta(key: string): boolean;
 
   /**
-   * Adds a new gxt text with the specified value.
+   * Adds a new gxt text with the specified value. FE_THDR_GTAO is locked and cannot be changed.
    * 
    * @param key Gxt text name.
    * @param value Gxt text value.


### PR DESCRIPTION
Explain that FE_THDR_GTAO is locked by alt:V to preserve the name in the pause menu