### PR TITLE
Made colshapeType an actual readonly

### DIFF
--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1028,7 +1028,7 @@ declare module "alt-server" {
   }
 
   export class Colshape extends WorldObject {
-    public colshapeType: ColShapeType;
+    public readonly colshapeType: ColShapeType;
 
     /**
      * Whether this colshape should only trigger its enter/leave events for players or all entities.


### PR DESCRIPTION
At this very moment, you can apply something to colshapeType.
Which causes an error:
```
[23:21:01][Error] [V8] Exception at core:file:///C:/alt%20V/Server/[Release]/resources/core/server.js:3328
[23:21:01][Error]           cp.colshapeType = 2 /* Circle */;
[23:21:01][Error]   TypeError: Cannot assign to read only property 'colshapeType' of object '#<ColshapeCircle>'
```