### PR TITLE
Fix alt.Player.local property type

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1171,10 +1171,8 @@ declare module "alt-client" {
 
     /**
      * The local player instance.
-     *
-     * @remarks Returns {@link LocalPlayer} in dev / rc.
      */
-    public static readonly local: Player | LocalPlayer;
+    public static readonly local: LocalPlayer;
 
     /** Player talking state */
     public readonly isTalking: boolean;


### PR DESCRIPTION
`alt.Player.local` returns `alt.LocalPlayer` on release branch too