### PR TITLE
Fix altv events autocomplete

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2335,12 +2335,28 @@ declare module "alt-client" {
   export function on<K extends keyof IClientEvent>(eventName: K, listener: IClientEvent[K]): void;
 
   /**
+   * Subscribes to a custom client event with the specified listener.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function on(eventName: string, listener: (...args: any[]) => void): void;
+
+  /**
    * Subscribes to a client event with the specified listener, which only triggers once.
    *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
   export function once<K extends keyof IClientEvent>(eventName: K, listener: IClientEvent[K]): void;
+
+  /**
+   * Subscribes to a custom client event with the specified listener, which only triggers once.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function once(eventName: string, listener: (...args: any[]) => void): void;
 
   /**
    * Subscribes to a server event with the specified listener.

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -834,7 +834,6 @@ declare module "alt-client" {
      * @beta
      */
     render: () => void;
-    [name: string]: (...args: any[]) => void;
     /**
      * @remarks See https://alloc8or.re/gta5/doc/enums/eTaskTypeIndex.txt for task ids.
      *

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -380,7 +380,6 @@ declare module "alt-server" {
     startFire: (player: Player, fires: Array<IFireInfo>) => boolean | void;
     startProjectile: (player: Player, pos: shared.Vector3, dir: shared.Vector3, ammoHash: number, weaponHash: number) => boolean | void;
     playerWeaponChange: (player: Player, oldWeapon: number, weapon: number) => void;
-    [name: string]: (...args: any[]) => void;
   }
 
   export interface IFireInfo {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1211,12 +1211,28 @@ declare module "alt-server" {
   export function on<K extends keyof IServerEvent>(eventName: K, listener: IServerEvent[K]): void;
 
   /**
+   * Subscribes to a custom server event with the specified listener.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function on(eventName: string, listener: (...args: any[]) => void): void;
+
+  /**
    * Subscribes to a server event with the specified listener, which only triggers once.
    *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
   export function once<K extends keyof IServerEvent>(eventName: K, listener: IServerEvent[K]): void;
+
+  /**
+   * Subscribes to a custom server event with the specified listener, which only triggers once.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function once(eventName: string, listener: (...args: any[]) => void): void;
 
   /**
    * Subscribes to a client event with the specified listener.


### PR DESCRIPTION
The altv events autocomplete was broken in VS Code because of index signature in `IClientEvent` and `IServerEvent`