### PR TITLE
worker: Separate event functions

### DIFF
--- a/worker/index.d.ts
+++ b/worker/index.d.ts
@@ -11,6 +11,41 @@ declare module "alt-worker" {
    * @returns The shared array buffer instance.
    */
   export function getSharedArrayBuffer(id: number): SharedArrayBuffer;
+  
+  /**
+   * Emits specified event across particular client.
+   *
+   * @param eventName Name of the event.
+   * @param args Rest parameters for emit to send.
+   */
+  export function emit(eventName: string, ...args: any[]): void;
 
-  export { on, once, emit, log, logWarning, logError, setTimeout, setInterval, nextTick, clearTimeout, clearInterval, clearNextTick, hash, version, branch, sdkVersion, debug, File, RGBA, Vector3, Vector2 } from "alt-client";
+  /**
+   * Unsubscribes from client event handler with specified listener.
+   *
+   * @remarks Listener should be of the same reference as when event was subscribed.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be removed.
+   */
+  export function off(eventName: string, listener: (...args: any[]) => void): void;
+
+  /**
+   * Subscribes to client event handler with specified listener.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function on(eventName: string, listener: (...args: any[]) => void): void;
+  
+  
+  /**
+   * Subscribes to a custom client event with the specified listener, which only triggers once.
+   *
+   * @param eventName Name of the event.
+   * @param listener Listener that should be added.
+   */
+  export function once(eventName: string, listener: (...args: any[]) => void): void;
+
+  export { log, logWarning, logError, setTimeout, setInterval, nextTick, clearTimeout, clearInterval, clearNextTick, hash, version, branch, sdkVersion, debug, File, RGBA, Vector3, Vector2 } from "alt-client";
 }

--- a/worker/index.d.ts
+++ b/worker/index.d.ts
@@ -21,23 +21,12 @@ declare module "alt-worker" {
   export function emit(eventName: string, ...args: any[]): void;
 
   /**
-   * Unsubscribes from client event handler with specified listener.
-   *
-   * @remarks Listener should be of the same reference as when event was subscribed.
-   *
-   * @param eventName Name of the event.
-   * @param listener Listener that should be removed.
-   */
-  export function off(eventName: string, listener: (...args: any[]) => void): void;
-
-  /**
    * Subscribes to client event handler with specified listener.
    *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
   export function on(eventName: string, listener: (...args: any[]) => void): void;
-  
   
   /**
    * Subscribes to a custom client event with the specified listener, which only triggers once.

--- a/worker/index.d.ts
+++ b/worker/index.d.ts
@@ -11,7 +11,7 @@ declare module "alt-worker" {
    * @returns The shared array buffer instance.
    */
   export function getSharedArrayBuffer(id: number): SharedArrayBuffer;
-  
+
   /**
    * Emits specified event across particular client.
    *
@@ -27,7 +27,7 @@ declare module "alt-worker" {
    * @param listener Listener that should be added.
    */
   export function on(eventName: string, listener: (...args: any[]) => void): void;
-  
+
   /**
    * Subscribes to a custom client event with the specified listener, which only triggers once.
    *


### PR DESCRIPTION
In order not to mix client internal alt:V events (`IClientEvent`)  with worker events

![image](https://user-images.githubusercontent.com/54737754/145391024-f136f6db-6fa2-40fb-8371-2cfe38ded5c1.png)
