### PR TITLE
Improve typing for meta functions

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -487,7 +487,7 @@ declare module "alt-client" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
     public getSyncedMeta<T = any>(key: string): T | undefined;
 
@@ -503,7 +503,7 @@ declare module "alt-client" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key or undefined if no data is present.or undefined if no data is present.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
     public getStreamSyncedMeta<T = any>(key: string): T | undefined;
 

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -487,15 +487,15 @@ declare module "alt-client" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.or undefined if no data is present.
      */
-    public getSyncedMeta(key: string): any;
+    public getSyncedMeta<T = any>(key: string): T | undefined;
 
     /**
      * Determines whether contains the specified key.
      *
      * @param key The key of the value to locate.
-     * @returns Return is dependent on whether element associated with the specified key is stored.
+     * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasSyncedMeta(key: string): boolean;
 
@@ -503,15 +503,15 @@ declare module "alt-client" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.or undefined if no data is present.
      */
-    public getStreamSyncedMeta(key: string): any;
+    public getStreamSyncedMeta<T = any>(key: string): T | undefined;
 
     /**
      * Determines whether contains the specified key.
      *
      * @param key The key of the value to locate.
-     * @returns Return is dependent on whether element associated with the specified key is stored.
+     * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasStreamSyncedMeta(key: string): boolean;
   }

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -573,7 +573,7 @@ declare module "alt-server" {
     public static getByID(id: number): Entity | null;
 
     /**
-     * Removes the specified key.
+     * Removes the specified key and the data connected to that specific key.
      *
      * @param key The key of the value to remove.
      */
@@ -583,15 +583,15 @@ declare module "alt-server" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getSyncedMeta(key: string): any;
+    public getSyncedMeta<T = any>(key: string): T | undefined;
 
     /**
      * Determines whether contains the specified key.
      *
      * @param key The key of the value to locate.
-     * @returns Return is dependent on whether element associated with the specified key is stored.
+     * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasSyncedMeta(key: string): boolean;
 
@@ -603,10 +603,10 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setSyncedMeta(key: string, value: any): void;
+    public setSyncedMeta<T = any>(key: string, value: T): void;
 
     /**
-     * Removes the specified key.
+     * Removes the specified key and the data connected to that specific key.
      *
      * @param key The key of the value to remove.
      */
@@ -616,15 +616,15 @@ declare module "alt-server" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getStreamSyncedMeta(key: string): any;
+    public getStreamSyncedMeta<T = any>(key: string): T | undefined;
 
     /**
      * Determines whether contains the specified key.
      *
      * @param key The key of the value to locate.
-     * @returns Return is dependent on whether element associated with the specified key is stored.
+     * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasStreamSyncedMeta(key: string): boolean;
 
@@ -636,7 +636,7 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setStreamSyncedMeta(key: string, value: any): void;
+    public setStreamSyncedMeta<T = any>(key: string, value: T): void;
 
     /**
      * Changes network owner to the specified player.
@@ -1043,7 +1043,7 @@ declare module "alt-server" {
      *
      * @beta
      */
-    public setLocalMeta(key: string, value: any): void;
+    public setLocalMeta<T = any>(key: string, value: T): void;
 
     /** @beta */
     public deleteLocalMeta(key: string): void;
@@ -1929,7 +1929,7 @@ declare module "alt-server" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
-  export function setSyncedMeta(key: string, value: any): void;
+  export function setSyncedMeta<T = any>(key: string, value: T): void;
 
   /**
    * Emits specified event to specific client.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1167,7 +1167,7 @@ declare module "alt-shared" {
     public destroy(): void;
 
     /**
-     * Removes the specified key.
+     * Removes the specified key and the data connected to that specific key.
      *
      * @param key The key of the value to remove.
      */
@@ -1177,9 +1177,9 @@ declare module "alt-shared" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getMeta(key: string): any;
+    public getMeta<T = any>(key: string): T | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -1195,8 +1195,9 @@ declare module "alt-shared" {
      * @remarks The given value will be shared locally.
      *
      * @param key The key of the value to store.
+     * @param value The value to store.
      */
-    public setMeta(key: string, value: any): void;
+    public setMeta<T = any>(key: string, value: T): void;
 
     /**
      * Returns the ref count of the entity.
@@ -1209,11 +1210,11 @@ declare module "alt-shared" {
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
-     * @returns Dynamic value associated with the specified key.
+     * @returns Dynamic value associated with the specified key or undefined if no data is present.
      *
      * @beta
      */
-    public getLocalMeta(key: string): any;
+    public getLocalMeta<T = any>(key: string): T | undefined;
 
     /** @beta */
     public hasLocalMeta(key: string): boolean;
@@ -1251,7 +1252,7 @@ declare module "alt-shared" {
   export const debug: boolean;
 
   /**
-   * Removes the specified key.
+   * Removes the specified key and the data connected to that specific key.
    *
    * @param key The key of the value to remove.
    */
@@ -1261,9 +1262,9 @@ declare module "alt-shared" {
    * Gets a value using the specified key.
    *
    * @param key The key of the value to get.
-   * @returns Dynamic value associated with the specified key.
+   * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getMeta(key: string): any;
+  export function getMeta<T = any>(key: string): T | undefined;
 
   /**
    * Determines whether contains the specified key.
@@ -1279,22 +1280,23 @@ declare module "alt-shared" {
    * @remarks The given value will be shared locally to all resources.
    *
    * @param key The key of the value to store.
+   * @param value The value to store.
    */
-  export function setMeta(key: string, value: any): void;
+  export function setMeta<T = any>(key: string, value: T): void;
 
   /**
    * Gets a value using the specified key.
    *
    * @param key The key of the value to get.
-   * @returns Dynamic value associated with the specified key.
+   * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getSyncedMeta(key: string): any;
+  export function getSyncedMeta<T = any>(key: string): T | undefined;
 
   /**
    * Determines whether contains the specified key.
    *
    * @param key The key of the value to locate.
-   * @returns Return is dependent on whether element associated with the specified key is stored.
+   * @returns True if the meta table contains any data at the specified key or False if not
    */
   export function hasSyncedMeta(key: string): boolean;
 


### PR DESCRIPTION
This PR improves the typings a bit for the meta functions. This allows to define the type of the data that we want to retrieve or store in the meta table. This also has the effect that the getter functions may or may not return undefined if the there is no data at the specified key which makes gamemodes depending on meta, safer.