### PR TITLE
Improve functions for getting event listeners

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1241,7 +1241,7 @@ declare module "alt-client" {
      * @param eventName Name of the event.
      * @returns Array of listener functions for that event.
      */
-    public getEventListeners(eventName: string | null): Function[];
+    public getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
     /**
      * Sets the specified header to the specified value.
@@ -2108,7 +2108,7 @@ declare module "alt-client" {
      * @param eventName Name of the event.
      * @returns Array of listener functions for that event.
      */
-    public getEventListeners(eventName: string | null): Function[];
+    public getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
   }
 
   /**
@@ -2151,7 +2151,7 @@ declare module "alt-client" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getEventListeners(eventName: string | null): Function[];
+  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
   /**
    * Gets all the listeners for the specified remote event.
@@ -2159,7 +2159,7 @@ declare module "alt-client" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getRemoteEventListeners(eventName: string | null): Function[];
+  export function getRemoteEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
   export class HttpClient extends shared.BaseObject {
     public constructor();
@@ -2342,7 +2342,7 @@ declare module "alt-client" {
 
     public off(eventName: string, func: (...args: any[]) => void): void;
 
-    public getEventListeners(eventName: string): Function[];
+    public getEventListeners(eventName: string): ((...args: any[]) => void)[];
 
     public readonly relativeOffset: shared.Vector2;
 

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2146,7 +2146,7 @@ declare module "alt-client" {
   export function evalModule(code: string): Record<string, any>;
 
   /**
-   * Gets all the listeners for the specified remote event.
+   * Gets all the listeners that have been subscribed using {@link onServer} for the specified remote event.
    *
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2146,14 +2146,6 @@ declare module "alt-client" {
   export function evalModule(code: string): Record<string, any>;
 
   /**
-   * Gets all the listeners for the specified local event.
-   *
-   * @param eventName Name of the event or null for generic event.
-   * @returns Array of listener functions for that event.
-   */
-  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
-
-  /**
    * Gets all the listeners for the specified remote event.
    *
    * @param eventName Name of the event or null for generic event.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2157,7 +2157,7 @@ declare module "alt-server" {
   export function stopResource(name: string): void;
 
   /**
-   * Gets all the listeners for the specified remote event.
+   * Gets all the listeners that have been subscribed using {@link onClient} for the specified remote event.
    *
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2157,14 +2157,6 @@ declare module "alt-server" {
   export function stopResource(name: string): void;
 
   /**
-   * Gets all the listeners for the specified local event.
-   *
-   * @param eventName Name of the event or null for generic event.
-   * @returns Array of listener functions for that event.
-   */
-  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
-
-  /**
    * Gets all the listeners for the specified remote event.
    *
    * @param eventName Name of the event or null for generic event.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2162,7 +2162,7 @@ declare module "alt-server" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getEventListeners(eventName: string | null): Function[];
+  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
   /**
    * Gets all the listeners for the specified remote event.
@@ -2170,7 +2170,7 @@ declare module "alt-server" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getRemoteEventListeners(eventName: string | null): Function[];
+  export function getRemoteEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
   /** @beta */
   export function getVehicleModelInfoByHash(vehicleHash: number): IVehicleModel;

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1483,4 +1483,12 @@ declare module "alt-shared" {
     public readonly all: Array<IResource>;
     public readonly current: IResource;
   }
+
+  /**
+   * Gets all the listeners for the specified local event.
+   *
+   * @param eventName Name of the event or null for generic event.
+   * @returns Array of listener functions for that event.
+   */
+  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 }


### PR DESCRIPTION
The [Fix listener in getEventListeners](https://github.com/altmp/altv-types/commit/2b128496356e43089c3247202f9ac8e73bd464b3) commit fixes the problem of type mismatch in on/off functions and getEventListeners

![image](https://user-images.githubusercontent.com/54737754/151614407-9094e183-127f-4c7e-afb0-456c77931dae.png)