### PR TITLE
Improvement of meta methods

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -516,7 +516,7 @@ declare module "alt-client" {
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K, value: ICustomEntityMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomEntityMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K, V>): void;
 
     public deleteMeta(key: string): void;
@@ -524,7 +524,7 @@ declare module "alt-client" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomEntityMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): ICustomEntityMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomEntityMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public hasMeta(key: string): boolean;
@@ -538,7 +538,7 @@ declare module "alt-client" {
      */
     public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntitySyncedMeta>): unknown;
     public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): shared.ICustomEntitySyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntitySyncedMeta} */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
@@ -558,7 +558,7 @@ declare module "alt-client" {
      */
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntityStreamSyncedMeta>): unknown;
     public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): shared.ICustomEntityStreamSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntityStreamSyncedMeta} */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
@@ -771,7 +771,7 @@ declare module "alt-client" {
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomPlayerMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
 
     public deleteMeta(key: string): void;
@@ -779,7 +779,7 @@ declare module "alt-client" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomPlayerMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public hasMeta(key: string): boolean;
@@ -789,7 +789,7 @@ declare module "alt-client" {
 
     public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerSyncedMeta>): unknown;
     public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): shared.ICustomPlayerSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerSyncedMeta} */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasSyncedMeta(key: string): boolean;
@@ -799,7 +799,7 @@ declare module "alt-client" {
 
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerStreamSyncedMeta>): unknown;
     public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): shared.ICustomPlayerStreamSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerStreamSyncedMeta} */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasStreamSyncedMeta(key: string): boolean;
@@ -1574,12 +1574,12 @@ declare module "alt-client" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomBlipMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): ICustomBlipMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBlipMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K, value: ICustomBlipMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBlipMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K, V>): void;
   }
 
@@ -2643,12 +2643,12 @@ declare module "alt-client" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
@@ -2660,7 +2660,7 @@ declare module "alt-client" {
    */
   export function getLocalMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerLocalMeta>): unknown;
   export function getLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): shared.ICustomPlayerLocalMeta[K] | undefined;
-  /** @deprecated */
+  /** @deprecated See {@link shared.ICustomPlayerLocalMeta} */
   export function getLocalMeta<V extends any>(key: string): V | undefined;
 
   export function hasLocalMeta(key: string): boolean;

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -344,16 +344,30 @@ declare module "alt-client" {
   }
 
   /**
+   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in player meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomBlipMeta extends ICustomBaseObjectMeta {}
+
+  /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
    *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
-  export interface ICustomEntityMeta {}
+  export interface ICustomEntityMeta extends ICustomBaseObjectMeta {}
 
   /**
    * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
    *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerMeta extends ICustomEntityMeta {}
 
@@ -1553,6 +1567,20 @@ declare module "alt-client" {
     public tickVisible: boolean;
 
     public fade(opacity: number, duration: number): void;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBlipMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): ICustomBlipMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K, value: ICustomBlipMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K, V>): void;
   }
 
   export class AreaBlip extends Blip {
@@ -2606,6 +2634,22 @@ declare module "alt-client" {
      * @alpha
      */
     public static requestCutscene(cutsceneName: string, flags: string | number, timeout?: number): Promise<void>;
+  }
+
+  export class BaseObject extends shared.BaseObject {
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
   /**

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -399,8 +399,24 @@ declare module "alt-client" {
    */
   export interface ICustomLocalPlayerMeta extends ICustomPlayerMeta {}
 
+  export class BaseObject extends shared.BaseObject {
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
+  }
+
   /** @beta */
-  export class Audio extends shared.BaseObject {
+  export class Audio extends BaseObject {
     /**
      * Creates a new Audio instance.
      *
@@ -466,7 +482,7 @@ declare module "alt-client" {
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomAudioMeta, K, V>): void;
   }
 
-  export class WorldObject extends shared.BaseObject {
+  export class WorldObject extends BaseObject {
     /**
      * Object position
      */
@@ -1281,7 +1297,7 @@ declare module "alt-client" {
     public static getByScriptID(scriptID: number): Vehicle | null;
   }
 
-  export class WebView extends shared.BaseObject {
+  export class WebView extends BaseObject {
     /** View visibility state */
     public isVisible: boolean;
     /** View URL */
@@ -2253,7 +2269,7 @@ declare module "alt-client" {
 
   export function toggleVoiceControls(state: boolean): void;
 
-  export class WebSocketClient extends shared.BaseObject {
+  export class WebSocketClient extends BaseObject {
     public autoReconnect: boolean;
 
     public perMessageDeflate: boolean;
@@ -2370,7 +2386,7 @@ declare module "alt-client" {
    */
   export function getRemoteEventListeners(eventName: string | null): ((...args: any[]) => void)[];
 
-  export class HttpClient extends shared.BaseObject {
+  export class HttpClient extends BaseObject {
     public constructor();
 
     public setExtraHeader(header: string, value: string): void;
@@ -2540,7 +2556,7 @@ declare module "alt-client" {
     public createTextNode(text: string): RmlElement;
   }
 
-  export class RmlElement extends shared.BaseObject {
+  export class RmlElement extends BaseObject {
     public on(eventName: string, func: (...args: any[]) => void): void;
 
     public off(eventName: string, func: (...args: any[]) => void): void;
@@ -2718,22 +2734,6 @@ declare module "alt-client" {
      * @alpha
      */
     public static requestCutscene(cutsceneName: string, flags: string | number, timeout?: number): Promise<void>;
-  }
-
-  export class BaseObject extends shared.BaseObject {
-    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
-
-    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
-
-    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
-    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
-    /** @deprecated See {@link ICustomBaseObjectMeta} */
-    public getMeta<V extends any>(key: string): V | undefined;
-
-    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
-    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
-    /** @deprecated See {@link ICustomBaseObjectMeta} */
-    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
   /**

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -343,6 +343,20 @@ declare module "alt-client" {
     readonly hitCount: number;
   }
 
+  /**
+   * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomEntityMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomPlayerMeta extends ICustomEntityMeta {}
+
   /** @beta */
   export class Audio extends shared.BaseObject {
     /**
@@ -486,13 +500,32 @@ declare module "alt-client" {
      */
     public static getByScriptID(scriptID: number): Entity | null;
 
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K, value: ICustomEntityMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K, V>): void;
+
+    public deleteMeta(key: string): void;
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): void;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomEntityMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): ICustomEntityMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public hasMeta(key: string): boolean;
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): boolean;
+
     /**
      * Gets a value using the specified key.
      *
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getSyncedMeta<T = any>(key: string): T | undefined;
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntitySyncedMeta>): unknown;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): shared.ICustomEntitySyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -501,6 +534,7 @@ declare module "alt-client" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasSyncedMeta(key: string): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): boolean;
 
     /**
      * Gets a value using the specified key.
@@ -508,7 +542,10 @@ declare module "alt-client" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getStreamSyncedMeta<T = any>(key: string): T | undefined;
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntityStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): shared.ICustomEntityStreamSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -517,6 +554,7 @@ declare module "alt-client" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasStreamSyncedMeta(key: string): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): boolean;
   }
 
   export class Player extends Entity {
@@ -714,6 +752,44 @@ declare module "alt-client" {
      * @alpha
      */
     //public readonly isStealthy: boolean;
+
+    // normal meta
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
+
+    public deleteMeta(key: string): void;
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public hasMeta(key: string): boolean;
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): boolean;
+
+    // synced meta
+
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerSyncedMeta>): unknown;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): shared.ICustomPlayerSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getSyncedMeta<V extends any>(key: string): V | undefined;
+
+    public hasSyncedMeta(key: string): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): boolean;
+
+    // stream synced meta
+
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): shared.ICustomPlayerStreamSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
+
+    public hasStreamSyncedMeta(key: string): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
   }
 
   export class LocalPlayer extends Player {
@@ -2499,9 +2575,13 @@ declare module "alt-client" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getLocalMeta<T = any>(key: string): T | undefined;
+  export function getLocalMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerLocalMeta>): unknown;
+  export function getLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): shared.ICustomPlayerLocalMeta[K] | undefined;
+  /** @deprecated */
+  export function getLocalMeta<V extends any>(key: string): V | undefined;
 
   export function hasLocalMeta(key: string): boolean;
+  export function hasLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): boolean;
 
   /**
    * Modify minimap component position.

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -344,18 +344,32 @@ declare module "alt-client" {
   }
 
   /**
-   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   * Extend it by interface merging for use in baseobject meta {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
-  export interface ICustomBaseObjectMeta {}
 
+  export interface ICustomBaseObjectMeta {}
   /**
-   * Extend it by merging interfaces for use in player meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
+   * Extend it by merging interfaces for use in blip meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomBlipMeta extends ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in checkpoint meta {@link Checkpoint#getMeta}, {@link Checkpoint#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomCheckpointMeta extends ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in webview meta {@link WebView#getMeta}, {@link WebView#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomWebViewMeta extends ICustomBaseObjectMeta {}
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
@@ -370,6 +384,13 @@ declare module "alt-client" {
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerMeta extends ICustomEntityMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in local player meta {@link LocalPlayer#getMeta}, {@link LocalPlayer#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomLocalPlayerMeta extends ICustomPlayerMeta {}
 
   /** @beta */
   export class Audio extends shared.BaseObject {
@@ -442,6 +463,20 @@ declare module "alt-client" {
 
     public isEntityIn(entity: Entity): boolean;
     public isPointIn(pos: shared.IVector3): boolean;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomCheckpointMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): ICustomCheckpointMeta[K] | undefined;
+    /** @deprecated See {@link ICustomCheckpointMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomCheckpointMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K, value: ICustomCheckpointMeta[K]): void;
+    /** @deprecated See {@link ICustomCheckpointMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomCheckpointMeta, K, V>): void;
   }
 
   export class Entity extends WorldObject {
@@ -813,6 +848,20 @@ declare module "alt-client" {
      * @returns Total ammo of the currently held weapon. 0 if no weapon is equipped.
      */
     public readonly currentAmmo: number;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomLocalPlayerMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomLocalPlayerMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomLocalPlayerMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomLocalPlayerMeta>>(key: K): ICustomLocalPlayerMeta[K] | undefined;
+    /** @deprecated See {@link ICustomLocalPlayerMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomLocalPlayerMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomLocalPlayerMeta>>(key: K, value: ICustomLocalPlayerMeta[K]): void;
+    /** @deprecated See {@link ICustomLocalPlayerMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomLocalPlayerMeta, K, V>): void;
   }
 
   export class Vehicle extends Entity {
@@ -1370,6 +1419,20 @@ declare module "alt-client" {
      * @param value Zoom level value.
      */
     public setZoomLevel(value: number): void;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomWebViewMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomWebViewMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomWebViewMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomWebViewMeta>>(key: K): ICustomWebViewMeta[K] | undefined;
+    /** @deprecated See {@link ICustomWebViewMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomWebViewMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomWebViewMeta>>(key: K, value: ICustomWebViewMeta[K]): void;
+    /** @deprecated See {@link ICustomWebViewMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomWebViewMeta, K, V>): void;
   }
 
   export class Worker {

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -349,7 +349,7 @@ declare module "alt-client" {
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
 
-  export interface ICustomBaseObjectMeta {}
+  export interface ICustomBaseObjectMeta extends shared.ICustomBaseObjectMeta {}
   /**
    * Extend it by merging interfaces for use in blip meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
    *
@@ -370,6 +370,13 @@ declare module "alt-client" {
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomWebViewMeta extends ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in audio meta {@link Audio#getMeta}, {@link Audio#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomAudioMeta extends ICustomBaseObjectMeta {}
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
@@ -443,6 +450,20 @@ declare module "alt-client" {
 
     public on(event: "streamEnded", callback: () => void): void;
     public on(event: "error", callback: (code: number, message: string) => void): void;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomAudioMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomAudioMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomAudioMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomAudioMeta>>(key: K): ICustomAudioMeta[K] | undefined;
+    /** @deprecated See {@link ICustomAudioMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomAudioMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomAudioMeta>>(key: K, value: ICustomAudioMeta[K]): void;
+    /** @deprecated See {@link ICustomAudioMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomAudioMeta, K, V>): void;
   }
 
   export class WorldObject extends shared.BaseObject {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -484,6 +484,26 @@ declare module "alt-server" {
   }
 
   /**
+   * Extend it using interface merging for using in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
+   */
+  export interface ICustomPlayerMeta {}
+
+  /**
+   * Extend it using interface merging for using in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
+   */
+  export interface ICustomPlayerSyncedMeta {}
+
+  /**
+   * Extend it using interface merging for using in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
+   */
+  export interface ICustomPlayerStreamSyncedMeta {}
+
+  /**
+   * Extend it using interface merging for using in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
+   */
+  export interface ICustomPlayerLocalMeta {}
+
+  /**
    * The root directory of the server.
    */
   export const rootDir: string;
@@ -1033,9 +1053,13 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setLocalMeta<T = any>(key: string, value: T): void;
+    public setLocalMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K>): void;
+    public setLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K, value: ICustomPlayerLocalMeta[K]): void;
+    /** @deprecated */
+    public setLocalMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K, V>): void;
 
     public deleteLocalMeta(key: string): void;
+    public deleteLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -1043,9 +1067,61 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getLocalMeta<T = any>(key: string): T | undefined;
+    public getLocalMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerLocalMeta>): unknown;
+    public getLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): ICustomPlayerLocalMeta[K] | undefined;
+    /** @deprecated */
+    public getLocalMeta<V extends any>(key: string): V | undefined;
 
     public hasLocalMeta(key: string): boolean;
+    public hasLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): boolean;
+
+    public deleteMeta(key: string): void;
+    public deleteMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerMeta>): unknown;
+    public getMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public hasMeta(key: string): boolean;
+    public hasMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): boolean;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
+    public setMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
+
+    public deleteSyncedMeta(key: string): void;
+    public deleteSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): void;
+
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerSyncedMeta>): unknown;
+    public getSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): ICustomPlayerSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getSyncedMeta<V extends any>(key: string): V | undefined;
+
+    public hasSyncedMeta(key: string): boolean;
+    public hasSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): boolean;
+
+    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K>): void;
+    public setSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
+    /** @deprecated */
+    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K, V>): void;
+
+    public deleteStreamSyncedMeta(key: string): void;
+    public deleteStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
+
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): ICustomPlayerStreamSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
+
+    public hasStreamSyncedMeta(key: string): boolean;
+    public hasStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
+
+    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K>): void;
+    public setStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
+    /** @deprecated */
+    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K, V>): void;
   }
 
   export class Vehicle extends Entity {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -601,7 +601,7 @@ declare module "alt-server" {
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K, value: ICustomEntityMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomEntityMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K, V>): void;
 
     public deleteMeta(key: string): void;
@@ -609,7 +609,7 @@ declare module "alt-server" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomEntityMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): ICustomEntityMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomEntityMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public hasMeta(key: string): boolean;
@@ -631,7 +631,7 @@ declare module "alt-server" {
      */
     public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntitySyncedMeta>): unknown;
     public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): shared.ICustomEntitySyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntitySyncedMeta} */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
@@ -653,7 +653,7 @@ declare module "alt-server" {
      */
     public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntitySyncedMeta, K>): void;
     public setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K, value: shared.ICustomEntitySyncedMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntitySyncedMeta} */
     public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntitySyncedMeta, K, V>): void;
 
     /**
@@ -672,7 +672,7 @@ declare module "alt-server" {
      */
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntityStreamSyncedMeta>): unknown;
     public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): shared.ICustomEntityStreamSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntityStreamSyncedMeta} */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
@@ -694,7 +694,7 @@ declare module "alt-server" {
      */
     public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntityStreamSyncedMeta, K>): void;
     public setStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K, value: shared.ICustomEntityStreamSyncedMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomEntityStreamSyncedMeta} */
     public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntityStreamSyncedMeta, K, V>): void;
 
     /**
@@ -1104,7 +1104,7 @@ declare module "alt-server" {
      */
     public setLocalMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerLocalMeta, K>): void;
     public setLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K, value: shared.ICustomPlayerLocalMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerLocalMeta} */
     public setLocalMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerLocalMeta, K, V>): void;
 
     public deleteLocalMeta(key: string): void;
@@ -1118,7 +1118,7 @@ declare module "alt-server" {
      */
     public getLocalMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerLocalMeta>): unknown;
     public getLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): shared.ICustomPlayerLocalMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerLocalMeta} */
     public getLocalMeta<V extends any>(key: string): V | undefined;
 
     public hasLocalMeta(key: string): boolean;
@@ -1128,7 +1128,7 @@ declare module "alt-server" {
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomPlayerMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
 
     public deleteMeta(key: string): void;
@@ -1136,7 +1136,7 @@ declare module "alt-server" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomPlayerMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public hasMeta(key: string): boolean;
@@ -1146,7 +1146,7 @@ declare module "alt-server" {
 
     public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerSyncedMeta, K>): void;
     public setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K, value: shared.ICustomPlayerSyncedMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerSyncedMeta} */
     public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerSyncedMeta, K, V>): void;
 
     public deleteSyncedMeta(key: string): void;
@@ -1154,7 +1154,7 @@ declare module "alt-server" {
 
     public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerSyncedMeta>): unknown;
     public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): shared.ICustomPlayerSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerSyncedMeta} */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasSyncedMeta(key: string): boolean;
@@ -1164,7 +1164,7 @@ declare module "alt-server" {
 
     public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerStreamSyncedMeta, K>): void;
     public setStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K, value: shared.ICustomPlayerStreamSyncedMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerStreamSyncedMeta} */
     public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerStreamSyncedMeta, K, V>): void;
 
     public deleteStreamSyncedMeta(key: string): void;
@@ -1172,7 +1172,7 @@ declare module "alt-server" {
 
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerStreamSyncedMeta>): unknown;
     public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): shared.ICustomPlayerStreamSyncedMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link shared.ICustomPlayerStreamSyncedMeta} */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasStreamSyncedMeta(key: string): boolean;
@@ -1984,12 +1984,12 @@ declare module "alt-server" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomBlipMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): ICustomBlipMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBlipMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K, value: ICustomBlipMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBlipMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K, V>): void;
   }
 
@@ -2090,12 +2090,12 @@ declare module "alt-server" {
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
     public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
     public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
@@ -2109,7 +2109,7 @@ declare module "alt-server" {
    */
   export function setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomGlobalSyncedMeta, K>): void;
   export function setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomGlobalSyncedMeta>>(key: K, value: shared.ICustomGlobalSyncedMeta[K]): void;
-  /** @deprecated */
+  /** @deprecated See {@link shared.ICustomGlobalSyncedMeta} */
   export function setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomGlobalSyncedMeta, K, V>): void;
 
   /**

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -484,22 +484,22 @@ declare module "alt-server" {
   }
 
   /**
-   * Extend it using interface merging for using in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
+   * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
    */
   export interface ICustomPlayerMeta {}
 
   /**
-   * Extend it using interface merging for using in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
+   * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
    */
   export interface ICustomPlayerSyncedMeta {}
 
   /**
-   * Extend it using interface merging for using in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
+   * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
    */
   export interface ICustomPlayerStreamSyncedMeta {}
 
   /**
-   * Extend it using interface merging for using in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
+   * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
    */
   export interface ICustomPlayerLocalMeta {}
 
@@ -1047,6 +1047,8 @@ declare module "alt-server" {
 
     public getHairHighlightColor(): number;
 
+    // local meta
+
     /**
      * Stores the given value with the specified key.
      *
@@ -1075,6 +1077,13 @@ declare module "alt-server" {
     public hasLocalMeta(key: string): boolean;
     public hasLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): boolean;
 
+    // normal meta
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
+    public setMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
+
     public deleteMeta(key: string): void;
     public deleteMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
 
@@ -1086,10 +1095,12 @@ declare module "alt-server" {
     public hasMeta(key: string): boolean;
     public hasMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): boolean;
 
-    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
-    public setMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
+    // synced meta
+
+    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K>): void;
+    public setSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
     /** @deprecated */
-    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
+    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K, V>): void;
 
     public deleteSyncedMeta(key: string): void;
     public deleteSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): void;
@@ -1102,13 +1113,15 @@ declare module "alt-server" {
     public hasSyncedMeta(key: string): boolean;
     public hasSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): boolean;
 
-    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K>): void;
-    public setSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
+    // stream synced meta
+
+    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K>): void;
+    public setStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
     /** @deprecated */
-    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K, V>): void;
+    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K, V>): void;
 
     public deleteStreamSyncedMeta(key: string): void;
-    public deleteStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
+    public deleteStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): void;
 
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerStreamSyncedMeta>): unknown;
     public getStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): ICustomPlayerStreamSyncedMeta[K] | undefined;
@@ -1117,11 +1130,6 @@ declare module "alt-server" {
 
     public hasStreamSyncedMeta(key: string): boolean;
     public hasStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
-
-    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K>): void;
-    public setStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
-    /** @deprecated */
-    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K, V>): void;
   }
 
   export class Vehicle extends Entity {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -541,7 +541,23 @@ declare module "alt-server" {
 
   export const globalDimension: number;
 
-  export class WorldObject extends shared.BaseObject {
+  export class BaseObject extends shared.BaseObject {
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
+  }
+
+  export class WorldObject extends BaseObject {
     /**
      * Object dimension.
      *
@@ -2098,7 +2114,7 @@ declare module "alt-server" {
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomCheckpointMeta, K, V>): void;
   }
 
-  export class VoiceChannel extends shared.BaseObject {
+  export class VoiceChannel extends BaseObject {
     /**
      * Creates a new voice channel.
      *
@@ -2144,22 +2160,6 @@ declare module "alt-server" {
   export class Resource extends shared.Resource {
     public readonly path: string;
     public readonly config: Record<string, any>;
-  }
-
-  export class BaseObject extends shared.BaseObject {
-    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
-
-    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
-
-    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
-    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
-    /** @deprecated See {@link ICustomBaseObjectMeta} */
-    public getMeta<V extends any>(key: string): V | undefined;
-
-    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
-    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
-    /** @deprecated See {@link ICustomBaseObjectMeta} */
-    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
   /**

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -484,18 +484,32 @@ declare module "alt-server" {
   }
 
   /**
-   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   * Extend it by interface merging for use in baseobject meta {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomBaseObjectMeta {}
 
   /**
-   * Extend it by merging interfaces for use in player meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
+   * Extend it by merging interfaces for use in blip meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomBlipMeta extends ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in colshape meta {@link Colshape#getMeta}, {@link Colshape#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomColshapeMeta extends ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in checkpoint meta {@link Checkpoint#getMeta}, {@link Checkpoint#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomCheckpointMeta extends ICustomColshapeMeta {}
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
@@ -2018,6 +2032,20 @@ declare module "alt-server" {
     public isEntityIn(entity: Entity): boolean;
 
     public isPointIn(position: shared.IVector3): boolean;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomColshapeMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomColshapeMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomColshapeMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomColshapeMeta>>(key: K): ICustomColshapeMeta[K] | undefined;
+    /** @deprecated See {@link ICustomColshapeMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomColshapeMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomColshapeMeta>>(key: K, value: ICustomColshapeMeta[K]): void;
+    /** @deprecated See {@link ICustomColshapeMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomColshapeMeta, K, V>): void;
   }
 
   export class ColshapeCylinder extends Colshape {
@@ -2047,6 +2075,20 @@ declare module "alt-server" {
   export class Checkpoint extends Colshape {
     constructor(type: number, x: number, y: number, z: number, radius: number, height: number, r: number, g: number, b: number, a: number);
     constructor(type: number, pos: shared.IVector3, radius: number, height: number, color: shared.RGBA);
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomCheckpointMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K): ICustomCheckpointMeta[K] | undefined;
+    /** @deprecated See {@link ICustomCheckpointMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomCheckpointMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomCheckpointMeta>>(key: K, value: ICustomCheckpointMeta[K]): void;
+    /** @deprecated See {@link ICustomCheckpointMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomCheckpointMeta, K, V>): void;
   }
 
   export class VoiceChannel extends shared.BaseObject {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -484,16 +484,30 @@ declare module "alt-server" {
   }
 
   /**
+   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomBaseObjectMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in player meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomBlipMeta extends ICustomBaseObjectMeta {}
+
+  /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
    *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
-  export interface ICustomEntityMeta {}
+  export interface ICustomEntityMeta extends ICustomBaseObjectMeta {}
 
   /**
    * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
    *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerMeta extends ICustomEntityMeta {}
 
@@ -1963,6 +1977,20 @@ declare module "alt-server" {
     public attachedTo: Entity | null;
 
     public fade(opacity: number, duration: number): void;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBlipMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K): ICustomBlipMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBlipMeta>>(key: K, value: ICustomBlipMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBlipMeta, K, V>): void;
   }
 
   export class AreaBlip extends Blip {
@@ -2053,6 +2081,22 @@ declare module "alt-server" {
   export class Resource extends shared.Resource {
     public readonly path: string;
     public readonly config: Record<string, any>;
+  }
+
+  export class BaseObject extends shared.BaseObject {
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
   }
 
   /**

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1056,12 +1056,12 @@ declare module "alt-server" {
      * @param value The value to store.
      */
     public setLocalMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K>): void;
-    public setLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K, value: ICustomPlayerLocalMeta[K]): void;
+    public setLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K, value: ICustomPlayerLocalMeta[K]): void;
     /** @deprecated */
     public setLocalMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K, V>): void;
 
     public deleteLocalMeta(key: string): void;
-    public deleteLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): void;
+    public deleteLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -1070,66 +1070,66 @@ declare module "alt-server" {
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
     public getLocalMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerLocalMeta>): unknown;
-    public getLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): ICustomPlayerLocalMeta[K] | undefined;
+    public getLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): ICustomPlayerLocalMeta[K] | undefined;
     /** @deprecated */
     public getLocalMeta<V extends any>(key: string): V | undefined;
 
     public hasLocalMeta(key: string): boolean;
-    public hasLocalMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): boolean;
+    public hasLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): boolean;
 
     // normal meta
 
     public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K>): void;
-    public setMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K, value: ICustomPlayerMeta[K]): void;
     /** @deprecated */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerMeta, K, V>): void;
 
     public deleteMeta(key: string): void;
-    public deleteMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): void;
 
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerMeta>): unknown;
-    public getMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): ICustomPlayerMeta[K] | undefined;
     /** @deprecated */
     public getMeta<V extends any>(key: string): V | undefined;
 
     public hasMeta(key: string): boolean;
-    public hasMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): boolean;
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomPlayerMeta>>(key: K): boolean;
 
     // synced meta
 
     public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K>): void;
-    public setSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
+    public setSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
     /** @deprecated */
     public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K, V>): void;
 
     public deleteSyncedMeta(key: string): void;
-    public deleteSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): void;
+    public deleteSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): void;
 
     public getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerSyncedMeta>): unknown;
-    public getSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): ICustomPlayerSyncedMeta[K] | undefined;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): ICustomPlayerSyncedMeta[K] | undefined;
     /** @deprecated */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasSyncedMeta(key: string): boolean;
-    public hasSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): boolean;
 
     // stream synced meta
 
     public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K>): void;
-    public setStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
+    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
     /** @deprecated */
     public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K, V>): void;
 
     public deleteStreamSyncedMeta(key: string): void;
-    public deleteStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): void;
+    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): void;
 
     public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerStreamSyncedMeta>): unknown;
-    public getStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): ICustomPlayerStreamSyncedMeta[K] | undefined;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): ICustomPlayerStreamSyncedMeta[K] | undefined;
     /** @deprecated */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasStreamSyncedMeta(key: string): boolean;
-    public hasStreamSyncedMeta<K extends keyof shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
   }
 
   export class Vehicle extends Entity {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -488,7 +488,7 @@ declare module "alt-server" {
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
-  export interface ICustomBaseObjectMeta {}
+  export interface ICustomBaseObjectMeta extends shared.ICustomBaseObjectMeta {}
 
   /**
    * Extend it by merging interfaces for use in blip meta {@link Blip#getMeta}, {@link Blip#setMeta}, etc.
@@ -510,6 +510,13 @@ declare module "alt-server" {
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomCheckpointMeta extends ICustomColshapeMeta {}
+
+  /**
+   * Extend it by merging interfaces for use in voice channel meta {@link VoiceChannel#getMeta}, {@link VoiceChannel#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomVoiceChannelMeta extends ICustomBaseObjectMeta {}
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
@@ -2113,6 +2120,20 @@ declare module "alt-server" {
     public removePlayer(player: Player): void;
 
     public unmutePlayer(player: Player): void;
+
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomVoiceChannelMeta>>(key: K): void;
+
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomVoiceChannelMeta>>(key: K): boolean;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomVoiceChannelMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomVoiceChannelMeta>>(key: K): ICustomVoiceChannelMeta[K] | undefined;
+    /** @deprecated See {@link ICustomVoiceChannelMeta} */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomVoiceChannelMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomVoiceChannelMeta>>(key: K, value: ICustomVoiceChannelMeta[K]): void;
+    /** @deprecated See {@link ICustomVoiceChannelMeta} */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomVoiceChannelMeta, K, V>): void;
 
     public readonly players: Array<Player>;
 

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -485,36 +485,49 @@ declare module "alt-server" {
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntityMeta {}
 
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntitySyncedMeta {}
 
   /**
    * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntityStreamSyncedMeta {}
 
   /**
    * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerMeta extends ICustomEntityMeta {}
 
   /**
    * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
+   *
+   * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerLocalMeta {}
 

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -491,45 +491,11 @@ declare module "alt-server" {
   export interface ICustomEntityMeta {}
 
   /**
-   * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
-   *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
-   */
-  export interface ICustomEntitySyncedMeta {}
-
-  /**
-   * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
-   * See {@link shared.ICustomGlobalMeta} for an example of use
-   */
-  export interface ICustomEntityStreamSyncedMeta {}
-
-  /**
    * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
    *
    * See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerMeta extends ICustomEntityMeta {}
-
-  /**
-   * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
-   *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
-   */
-  export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
-
-  /**
-   * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
-   *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
-   */
-  export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
-
-  /**
-   * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
-   *
-   * See {@link shared.ICustomGlobalMeta} for an example of use
-   */
-  export interface ICustomPlayerLocalMeta {}
 
   /**
    * The root directory of the server.
@@ -641,7 +607,7 @@ declare module "alt-server" {
      * @param key The key of the value to remove.
      */
     public deleteSyncedMeta(key: string): void;
-    public deleteSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): void;
+    public deleteSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -649,8 +615,8 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomEntitySyncedMeta>): unknown;
-    public getSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): ICustomEntitySyncedMeta[K] | undefined;
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntitySyncedMeta>): unknown;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): shared.ICustomEntitySyncedMeta[K] | undefined;
     /** @deprecated */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
@@ -661,7 +627,7 @@ declare module "alt-server" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasSyncedMeta(key: string): boolean;
-    public hasSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): boolean;
 
     /**
      * Stores the given value with the specified key.
@@ -671,10 +637,10 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntitySyncedMeta, K>): void;
-    public setSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K, value: ICustomEntitySyncedMeta[K]): void;
+    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntitySyncedMeta, K>): void;
+    public setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K, value: shared.ICustomEntitySyncedMeta[K]): void;
     /** @deprecated */
-    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntitySyncedMeta, K, V>): void;
+    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntitySyncedMeta, K, V>): void;
 
     /**
      * Removes the specified key and the data connected to that specific key.
@@ -682,7 +648,7 @@ declare module "alt-server" {
      * @param key The key of the value to remove.
      */
     public deleteStreamSyncedMeta(key: string): void;
-    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): void;
+    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -690,8 +656,8 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomEntityStreamSyncedMeta>): unknown;
-    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): ICustomEntityStreamSyncedMeta[K] | undefined;
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomEntityStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): shared.ICustomEntityStreamSyncedMeta[K] | undefined;
     /** @deprecated */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
@@ -702,7 +668,7 @@ declare module "alt-server" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasStreamSyncedMeta(key: string): boolean;
-    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): boolean;
 
     /**
      * Stores the given value with the specified key.
@@ -712,10 +678,10 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityStreamSyncedMeta, K>): void;
-    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K, value: ICustomEntityStreamSyncedMeta[K]): void;
+    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntityStreamSyncedMeta, K>): void;
+    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K, value: shared.ICustomEntityStreamSyncedMeta[K]): void;
     /** @deprecated */
-    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityStreamSyncedMeta, K, V>): void;
+    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomEntityStreamSyncedMeta, K, V>): void;
 
     /**
      * Changes network owner to the specified player.
@@ -1115,13 +1081,13 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setLocalMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K>): void;
-    public setLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K, value: ICustomPlayerLocalMeta[K]): void;
+    public setLocalMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerLocalMeta, K>): void;
+    public setLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K, value: shared.ICustomPlayerLocalMeta[K]): void;
     /** @deprecated */
-    public setLocalMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerLocalMeta, K, V>): void;
+    public setLocalMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerLocalMeta, K, V>): void;
 
     public deleteLocalMeta(key: string): void;
-    public deleteLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): void;
+    public deleteLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -1129,13 +1095,13 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getLocalMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerLocalMeta>): unknown;
-    public getLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): ICustomPlayerLocalMeta[K] | undefined;
+    public getLocalMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerLocalMeta>): unknown;
+    public getLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): shared.ICustomPlayerLocalMeta[K] | undefined;
     /** @deprecated */
     public getLocalMeta<V extends any>(key: string): V | undefined;
 
     public hasLocalMeta(key: string): boolean;
-    public hasLocalMeta<K extends shared.ExtractStringKeys<ICustomPlayerLocalMeta>>(key: K): boolean;
+    public hasLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): boolean;
 
     // normal meta
 
@@ -1157,39 +1123,39 @@ declare module "alt-server" {
 
     // synced meta
 
-    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K>): void;
-    public setSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K, value: ICustomPlayerSyncedMeta[K]): void;
+    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerSyncedMeta, K>): void;
+    public setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K, value: shared.ICustomPlayerSyncedMeta[K]): void;
     /** @deprecated */
-    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerSyncedMeta, K, V>): void;
+    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerSyncedMeta, K, V>): void;
 
     public deleteSyncedMeta(key: string): void;
-    public deleteSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): void;
+    public deleteSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): void;
 
-    public getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerSyncedMeta>): unknown;
-    public getSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): ICustomPlayerSyncedMeta[K] | undefined;
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerSyncedMeta>): unknown;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): shared.ICustomPlayerSyncedMeta[K] | undefined;
     /** @deprecated */
     public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasSyncedMeta(key: string): boolean;
-    public hasSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerSyncedMeta>>(key: K): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerSyncedMeta>>(key: K): boolean;
 
     // stream synced meta
 
-    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K>): void;
-    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K, value: ICustomPlayerStreamSyncedMeta[K]): void;
+    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerStreamSyncedMeta, K>): void;
+    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K, value: shared.ICustomPlayerStreamSyncedMeta[K]): void;
     /** @deprecated */
-    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomPlayerStreamSyncedMeta, K, V>): void;
+    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomPlayerStreamSyncedMeta, K, V>): void;
 
     public deleteStreamSyncedMeta(key: string): void;
-    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): void;
+    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): void;
 
-    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomPlayerStreamSyncedMeta>): unknown;
-    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): ICustomPlayerStreamSyncedMeta[K] | undefined;
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof shared.ICustomPlayerStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): shared.ICustomPlayerStreamSyncedMeta[K] | undefined;
     /** @deprecated */
     public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     public hasStreamSyncedMeta(key: string): boolean;
-    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
   }
 
   export class Vehicle extends Entity {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -484,19 +484,34 @@ declare module "alt-server" {
   }
 
   /**
+   * Extend it by interface merging for use in entity meta {@link Entity#getMeta}, {@link Entity#setMeta}, etc.
+   */
+  export interface ICustomEntityMeta {}
+
+  /**
+   * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
+   */
+  export interface ICustomEntitySyncedMeta {}
+
+  /**
+   * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
+   */
+  export interface ICustomEntityStreamSyncedMeta {}
+
+  /**
    * Extend it by merging interfaces for use in player meta {@link Player#getMeta}, {@link Player#setMeta}, etc.
    */
-  export interface ICustomPlayerMeta {}
+  export interface ICustomPlayerMeta extends ICustomEntityMeta {}
 
   /**
    * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
    */
-  export interface ICustomPlayerSyncedMeta {}
+  export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
    */
-  export interface ICustomPlayerStreamSyncedMeta {}
+  export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
@@ -591,12 +606,29 @@ declare module "alt-server" {
      */
     public static getByID(id: number): Entity | null;
 
+    public setMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K>): void;
+    public setMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K, value: ICustomEntityMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityMeta, K, V>): void;
+
+    public deleteMeta(key: string): void;
+    public deleteMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): void;
+
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomEntityMeta>): unknown;
+    public getMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): ICustomEntityMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
+
+    public hasMeta(key: string): boolean;
+    public hasMeta<K extends shared.ExtractStringKeys<ICustomEntityMeta>>(key: K): boolean;
+
     /**
      * Removes the specified key and the data connected to that specific key.
      *
      * @param key The key of the value to remove.
      */
     public deleteSyncedMeta(key: string): void;
+    public deleteSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -604,7 +636,10 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getSyncedMeta<T = any>(key: string): T | undefined;
+    public getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomEntitySyncedMeta>): unknown;
+    public getSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): ICustomEntitySyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -613,6 +648,7 @@ declare module "alt-server" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasSyncedMeta(key: string): boolean;
+    public hasSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K): boolean;
 
     /**
      * Stores the given value with the specified key.
@@ -622,7 +658,10 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setSyncedMeta<T = any>(key: string, value: T): void;
+    public setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntitySyncedMeta, K>): void;
+    public setSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntitySyncedMeta>>(key: K, value: ICustomEntitySyncedMeta[K]): void;
+    /** @deprecated */
+    public setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntitySyncedMeta, K, V>): void;
 
     /**
      * Removes the specified key and the data connected to that specific key.
@@ -630,6 +669,7 @@ declare module "alt-server" {
      * @param key The key of the value to remove.
      */
     public deleteStreamSyncedMeta(key: string): void;
+    public deleteStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -637,7 +677,10 @@ declare module "alt-server" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getStreamSyncedMeta<T = any>(key: string): T | undefined;
+    public getStreamSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomEntityStreamSyncedMeta>): unknown;
+    public getStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): ICustomEntityStreamSyncedMeta[K] | undefined;
+    /** @deprecated */
+    public getStreamSyncedMeta<V extends any>(key: string): V | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -646,6 +689,7 @@ declare module "alt-server" {
      * @returns True if the meta table contains any data at the specified key or False if not
      */
     public hasStreamSyncedMeta(key: string): boolean;
+    public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K): boolean;
 
     /**
      * Stores the given value with the specified key.
@@ -655,7 +699,10 @@ declare module "alt-server" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setStreamSyncedMeta<T = any>(key: string, value: T): void;
+    public setStreamSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityStreamSyncedMeta, K>): void;
+    public setStreamSyncedMeta<K extends shared.ExtractStringKeys<ICustomEntityStreamSyncedMeta>>(key: K, value: ICustomEntityStreamSyncedMeta[K]): void;
+    /** @deprecated */
+    public setStreamSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomEntityStreamSyncedMeta, K, V>): void;
 
     /**
      * Changes network owner to the specified player.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2045,7 +2045,10 @@ declare module "alt-server" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
-  export function setSyncedMeta<T = any>(key: string, value: T): void;
+  export function setSyncedMeta<K extends string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomGlobalSyncedMeta, K>): void;
+  export function setSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomGlobalSyncedMeta>>(key: K, value: shared.ICustomGlobalSyncedMeta[K]): void;
+  /** @deprecated */
+  export function setSyncedMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<shared.ICustomGlobalSyncedMeta, K, V>): void;
 
   /**
    * Removes the specified key and the data connected to that specific key.
@@ -2053,6 +2056,7 @@ declare module "alt-server" {
    * @param key The key of the value to remove.
    */
   export function deleteSyncedMeta(key: string): void;
+  export function deleteSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomGlobalSyncedMeta>>(key: K): void;
 
   /**
    * Emits specified event to specific client.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1520,7 +1520,7 @@ declare module "alt-shared" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getMeta(key: string): unknown;
+  export function getMeta<K extends string>(key: Exclude<K, keyof ICustomGlobalMeta>): unknown;
   export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
   /** @deprecated */
   export function getMeta<V extends any>(key: string): V | undefined;

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -925,6 +925,13 @@ declare module "alt-shared" {
    */
   export interface ICustomGlobalMeta {}
 
+  /**
+   * Extracts string keys from interface
+   */
+  type ExtractStringKeys<T extends Record<any, any>> = {
+    [K in keyof T as Extract<K, string>]: T[K];
+  };
+
   export class Vector3 {
     public readonly x: number;
 
@@ -1475,7 +1482,9 @@ declare module "alt-shared" {
    *
    * @param key The key of the value to remove.
    */
-  export function deleteMeta<K extends keyof ICustomGlobalMeta>(key: K): void;
+  // export function deleteMeta<K extends keyof StringOnlyKeys<ICustomGlobalMeta>>(key: K extends number ? never : K): void;
+  export function deleteMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
+  export function deleteMeta(key: string): void;
 
   /**
    * Gets a value using the specified key.
@@ -1483,7 +1492,8 @@ declare module "alt-shared" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getMeta<K extends keyof ICustomGlobalMeta>(key: K): ICustomGlobalMeta[K] | undefined;
+  export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
+  export function getMeta(key: string): unknown;
 
   /**
    * Determines whether contains the specified key.
@@ -1491,7 +1501,8 @@ declare module "alt-shared" {
    * @param key The key of the value to locate.
    * @returns True when element associated with the specified key is stored.
    */
-  export function hasMeta<K extends keyof ICustomGlobalMeta>(key: K): boolean;
+  export function hasMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): boolean;
+  export function hasMeta(key: string): boolean;
 
   /**
    * Stores the given value with the specified key.
@@ -1501,7 +1512,8 @@ declare module "alt-shared" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
-  export function setMeta<K extends keyof ICustomGlobalMeta>(key: K, value: ICustomGlobalMeta[K]): void;
+  export function setMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
+  export function setMeta(key: string, value: unknown): void;
 
   /**
    * Gets a value using the specified key.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -930,11 +930,11 @@ declare module "alt-shared" {
   /**
    * This is an internal utility type and you probably don't need it
    *
-   * Extracts string keys from interface
+   * Extracts string keys from interface and transforms them to a string union
    *
    * @hidden
    */
-  type ExtractStringKeys<TInterface extends Record<any, any>> = {
+  type ExtractStringKeys<TInterface extends Record<any, any>> = keyof {
     [K in keyof TInterface as Extract<K, string>]: TInterface[K];
   };
 
@@ -955,7 +955,7 @@ declare module "alt-shared" {
   }
 
   /**
-   * Extend it using interface merging for using in alt.{@link getMeta}, alt.{@link setMeta}, etc.
+   * Extend it by interface merging for use in alt.{@link getMeta}, alt.{@link setMeta}, etc.
    */
   export interface ICustomGlobalMeta {}
 
@@ -1512,7 +1512,7 @@ declare module "alt-shared" {
    * @param key The key of the value to remove.
    */
   export function deleteMeta(key: string): void;
-  export function deleteMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
+  export function deleteMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
 
   /**
    * Gets a value using the specified key.
@@ -1521,7 +1521,7 @@ declare module "alt-shared" {
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
   export function getMeta<K extends string>(key: Exclude<K, keyof ICustomGlobalMeta>): unknown;
-  export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
+  export function getMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
   /** @deprecated */
   export function getMeta<V extends any>(key: string): V | undefined;
 
@@ -1532,7 +1532,7 @@ declare module "alt-shared" {
    * @returns True when element associated with the specified key is stored.
    */
   export function hasMeta(key: string): boolean;
-  export function hasMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): boolean;
+  export function hasMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K): boolean;
 
   /**
    * Stores the given value with the specified key.
@@ -1543,7 +1543,7 @@ declare module "alt-shared" {
    * @param value The value to store.
    */
   export function setMeta<K extends string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K>): void;
-  export function setMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
+  export function setMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
   /** @deprecated */
   export function setMeta<V extends any, K extends string = string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K, V>): void;
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -955,7 +955,7 @@ declare module "alt-shared" {
   }
 
   /**
-   * Extend it by interface merging for use in {@link getMeta alt.getMeta}, {@link setMeta alt.setMeta}, etc.
+   * Extend it by interface merging for use in global meta {@link getMeta alt.getMeta}, {@link setMeta alt.setMeta}, etc.
    *
    * @example
    * ```
@@ -974,49 +974,49 @@ declare module "alt-shared" {
   export interface ICustomGlobalMeta {}
 
   /**
-   * Extend it by interface merging for use in {@link getSyncedMeta alt.getSyncedMeta}, {@link setSyncedMeta alt.setSyncedMeta}, etc.
+   * Extend it by interface merging for use in global synced meta {@link getSyncedMeta alt.getSyncedMeta}, {@link setSyncedMeta alt.setSyncedMeta}, etc.
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomGlobalSyncedMeta {}
 
   /**
-   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   * Extend it by interface merging for use in baseobject meta {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
    *
    * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
    */
   export interface ICustomBaseObjectMeta {}
 
   /**
-   * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
+   * Extend it by interface merging for use in entity synced meta (class `Entity` on client & server, e.g. `entity.getSyncedMeta`)
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntitySyncedMeta {}
 
   /**
-   * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
+   * Extend it by interface merging for use in entity stream synced meta (class `Entity` on client & server, e.g. `entity.getStreamSyncedMeta`)
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntityStreamSyncedMeta {}
 
   /**
-   * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
+   * Extend it by interface merging for use in player synced meta (class `Player` on client & server, e.g. `player.getSyncedMeta`)
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
 
   /**
-   * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
+   * Extend it by interface merging for use in player stream synced meta (class `Player` on client & server, e.g. `player.getStreamSyncedMeta`)
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
 
   /**
-   * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
+   * Extend it by interface merging for use in player local meta (class `Player` on client & server, e.g. `player.getLocalMeta`)
    *
    * @remarks See {@link ICustomGlobalMeta} for an example of use
    */

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -968,50 +968,57 @@ declare module "alt-shared" {
    * }
    *
    * const value = alt.getMeta("numberExample") // return value: number | undefined
-   * alt.setMeta("stringExample", "value") // params key: "numberExample", value: string
+   * alt.setMeta("stringExample", "value") // key: "stringExample", value: string
    * ```
    */
   export interface ICustomGlobalMeta {}
 
-
   /**
    * Extend it by interface merging for use in {@link getSyncedMeta alt.getSyncedMeta}, {@link setSyncedMeta alt.setSyncedMeta}, etc.
    *
-   * See {@link ICustomGlobalMeta} for an example of use
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomGlobalSyncedMeta {}
 
   /**
+   * Extend it by interface merging for use in {@link BaseObject#getMeta}, {@link BaseObject#setMeta}, etc.
+   *
+   * @remarks See {@link shared.ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomBaseObjectMeta {}
+
+  /**
    * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
    *
-   * See {@link ICustomGlobalMeta} for an example of use
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntitySyncedMeta {}
 
   /**
    * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
-   * See {@link ICustomGlobalMeta} for an example of use
+   *
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomEntityStreamSyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
    *
-   * See {@link ICustomGlobalMeta} for an example of use
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
    *
-   * See {@link ICustomGlobalMeta} for an example of use
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
 
   /**
    * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
    *
-   * See {@link ICustomGlobalMeta} for an example of use
+   * @remarks See {@link ICustomGlobalMeta} for an example of use
    */
   export interface ICustomPlayerLocalMeta {}
 
@@ -1494,6 +1501,7 @@ declare module "alt-shared" {
      * @param key The key of the value to remove.
      */
     public deleteMeta(key: string): void;
+    public deleteMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): void;
 
     /**
      * Gets a value using the specified key.
@@ -1501,7 +1509,10 @@ declare module "alt-shared" {
      * @param key The key of the value to get.
      * @returns Dynamic value associated with the specified key or undefined if no data is present.
      */
-    public getMeta<T = any>(key: string): T | undefined;
+    public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
+    public getMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
+    /** @deprecated */
+    public getMeta<V extends any>(key: string): V | undefined;
 
     /**
      * Determines whether contains the specified key.
@@ -1510,6 +1521,7 @@ declare module "alt-shared" {
      * @returns True when element associated with the specified key is stored.
      */
     public hasMeta(key: string): boolean;
+    public hasMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
 
     /**
      * Stores the given value with the specified key.
@@ -1519,7 +1531,10 @@ declare module "alt-shared" {
      * @param key The key of the value to store.
      * @param value The value to store.
      */
-    public setMeta<T = any>(key: string, value: T): void;
+    public setMeta<K extends string>(key: K, value: InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
+    public setMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
+    /** @deprecated */
+    public setMeta<V extends any, K extends string = string>(key: K, value: InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
 
     /**
      * Returns the ref count of the entity.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -973,6 +973,14 @@ declare module "alt-shared" {
    */
   export interface ICustomGlobalMeta {}
 
+
+  /**
+   * Extend it by interface merging for use in {@link getSyncedMeta alt.getSyncedMeta}, {@link setSyncedMeta alt.setSyncedMeta}, etc.
+   *
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomGlobalSyncedMeta {}
+
   /**
    * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
    *
@@ -1601,7 +1609,10 @@ declare module "alt-shared" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getSyncedMeta<T = any>(key: string): T | undefined;
+  export function getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomGlobalSyncedMeta>): unknown;
+  export function getSyncedMeta<K extends ExtractStringKeys<ICustomGlobalSyncedMeta>>(key: K): ICustomGlobalSyncedMeta[K] | undefined;
+  /** @deprecated */
+  export function getSyncedMeta<V extends any>(key: string): V | undefined;
 
   /**
    * Determines whether contains the specified key.
@@ -1610,6 +1621,7 @@ declare module "alt-shared" {
    * @returns True if the meta table contains any data at the specified key or False if not
    */
   export function hasSyncedMeta(key: string): boolean;
+  export function hasSyncedMeta<K extends ExtractStringKeys<ICustomGlobalSyncedMeta>>(key: K): boolean;
 
   /**
    * Clears a timer set with the {@link everyTick} function.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -932,6 +932,11 @@ declare module "alt-shared" {
     [K in keyof T as Extract<K, string>]: T[K];
   };
 
+  /**
+   * Gets a type of value for key from meta interface
+   */
+  type GetMetaKeyValue<T extends Record<any, any>, K> = K extends keyof T ? T[K] : unknown;
+
   export class Vector3 {
     public readonly x: number;
 
@@ -1512,8 +1517,8 @@ declare module "alt-shared" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
+  export function setMeta<K extends string>(key: K, value: GetMetaKeyValue<ICustomGlobalMeta, K>): void;
   export function setMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
-  export function setMeta(key: string, value: unknown): void;
 
   /**
    * Gets a value using the specified key.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -973,6 +973,40 @@ declare module "alt-shared" {
    */
   export interface ICustomGlobalMeta {}
 
+  /**
+   * Extend it by interface merging for use in entity meta {@link Entity#getSyncedMeta}, {@link Entity#setSyncedMeta}, etc.
+   *
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+   export interface ICustomEntitySyncedMeta {}
+
+   /**
+    * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
+    * See {@link ICustomGlobalMeta} for an example of use
+    */
+   export interface ICustomEntityStreamSyncedMeta {}
+
+   /**
+   * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
+   *
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomPlayerSyncedMeta extends ICustomEntitySyncedMeta {}
+
+  /**
+   * Extend it by interface merging for use in player stream synced meta {@link Player#getStreamSyncedMeta}, {@link Player#setStreamSyncedMeta}, etc.
+   *
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomPlayerStreamSyncedMeta extends ICustomEntityStreamSyncedMeta {}
+
+  /**
+   * Extend it by interface merging for use in player local meta {@link Player#getLocalMeta}, {@link Player#setLocalMeta}, etc.
+   *
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomPlayerLocalMeta {}
+
   export class Vector3 {
     public readonly x: number;
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -936,7 +936,7 @@ declare module "alt-shared" {
    */
   type ExtractStringKeys<TInterface extends Record<any, any>> = {
     [K in keyof TInterface as Extract<K, string>]: TInterface[K];
-  }
+  };
 
   export interface IVector2 {
     readonly x: number;
@@ -957,7 +957,7 @@ declare module "alt-shared" {
   /**
    * Extend it using interface merging for using in alt.{@link getMeta}, alt.{@link setMeta}, etc.
    */
-  export interface ICustomGlobalMeta { }
+  export interface ICustomGlobalMeta {}
 
   export class Vector3 {
     public readonly x: number;

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1493,8 +1493,8 @@ declare module "alt-shared" {
    *
    * @param key The key of the value to remove.
    */
-  export function deleteMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
   export function deleteMeta(key: string): void;
+  export function deleteMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
 
   /**
    * Gets a value using the specified key.
@@ -1502,8 +1502,8 @@ declare module "alt-shared" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
   export function getMeta(key: string): unknown;
+  export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
   /** @deprecated */
   export function getMeta<V extends any>(key: string): V | undefined;
 
@@ -1513,8 +1513,8 @@ declare module "alt-shared" {
    * @param key The key of the value to locate.
    * @returns True when element associated with the specified key is stored.
    */
-  export function hasMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): boolean;
   export function hasMeta(key: string): boolean;
+  export function hasMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): boolean;
 
   /**
    * Stores the given value with the specified key.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -927,6 +927,17 @@ declare module "alt-shared" {
       : VDefault
   );
 
+  /**
+   * This is an internal utility type and you probably don't need it
+   *
+   * Extracts string keys from interface
+   *
+   * @hidden
+   */
+  type ExtractStringKeys<TInterface extends Record<any, any>> = {
+    [K in keyof TInterface as Extract<K, string>]: TInterface[K];
+  }
+
   export interface IVector2 {
     readonly x: number;
     readonly y: number;
@@ -946,23 +957,7 @@ declare module "alt-shared" {
   /**
    * Extend it using interface merging for using in alt.{@link getMeta}, alt.{@link setMeta}, etc.
    */
-  export interface ICustomGlobalMeta {}
-
-  /**
-   * Extracts string keys from interface
-   */
-  type ExtractStringKeys<T extends Record<any, any>> = {
-    [K in keyof T as Extract<K, string>]: T[K];
-  };
-
-  /**
-   * Gets a type of value for key from meta interface
-   *
-   * * T - meta interface
-   * * K - meta key
-   * * VDefault - default K (meta value) if key is missing in T (meta interface).
-   */
-  type GetMetaKeyValue<T extends Record<any, any>, K, VDefault = unknown> = K extends keyof T ? T[K] : VDefault;
+  export interface ICustomGlobalMeta { }
 
   export class Vector3 {
     public readonly x: number;
@@ -1547,10 +1542,10 @@ declare module "alt-shared" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
-  export function setMeta<K extends string>(key: K, value: GetMetaKeyValue<ICustomGlobalMeta, K>): void;
+  export function setMeta<K extends string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K>): void;
   export function setMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
   /** @deprecated */
-  export function setMeta<V extends any, K extends string = string>(key: K, value: GetMetaKeyValue<ICustomGlobalMeta, K, V>): void;
+  export function setMeta<V extends any, K extends string = string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K, V>): void;
 
   /**
    * Gets a value using the specified key.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -978,15 +978,15 @@ declare module "alt-shared" {
    *
    * See {@link ICustomGlobalMeta} for an example of use
    */
-   export interface ICustomEntitySyncedMeta {}
+  export interface ICustomEntitySyncedMeta {}
 
-   /**
-    * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
-    * See {@link ICustomGlobalMeta} for an example of use
-    */
-   export interface ICustomEntityStreamSyncedMeta {}
+  /**
+   * Extend it by interface merging for use in entity stream synced meta {@link Entity#getStreamSyncedMeta}, {@link Entity#setStreamSyncedMeta}, etc.
+   * See {@link ICustomGlobalMeta} for an example of use
+   */
+  export interface ICustomEntityStreamSyncedMeta {}
 
-   /**
+  /**
    * Extend it by interface merging for use in player meta {@link Player#getSyncedMeta}, {@link Player#setSyncedMeta}, etc.
    *
    * See {@link ICustomGlobalMeta} for an example of use

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1511,7 +1511,7 @@ declare module "alt-shared" {
      */
     public getMeta<K extends string>(key: Exclude<K, keyof ICustomBaseObjectMeta>): unknown;
     public getMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): ICustomBaseObjectMeta[K] | undefined;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public getMeta<V extends any>(key: string): V | undefined;
 
     /**
@@ -1533,7 +1533,7 @@ declare module "alt-shared" {
      */
     public setMeta<K extends string>(key: K, value: InterfaceValueByKey<ICustomBaseObjectMeta, K>): void;
     public setMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K, value: ICustomBaseObjectMeta[K]): void;
-    /** @deprecated */
+    /** @deprecated See {@link ICustomBaseObjectMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: InterfaceValueByKey<ICustomBaseObjectMeta, K, V>): void;
 
     /**
@@ -1593,7 +1593,7 @@ declare module "alt-shared" {
    */
   export function getMeta<K extends string>(key: Exclude<K, keyof ICustomGlobalMeta>): unknown;
   export function getMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
-  /** @deprecated */
+  /** @deprecated See {@link ICustomGlobalMeta} */
   export function getMeta<V extends any>(key: string): V | undefined;
 
   /**
@@ -1615,7 +1615,7 @@ declare module "alt-shared" {
    */
   export function setMeta<K extends string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K>): void;
   export function setMeta<K extends ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
-  /** @deprecated */
+  /** @deprecated See {@link ICustomGlobalMeta} */
   export function setMeta<V extends any, K extends string = string>(key: K, value: InterfaceValueByKey<ICustomGlobalMeta, K, V>): void;
 
   /**
@@ -1626,7 +1626,7 @@ declare module "alt-shared" {
    */
   export function getSyncedMeta<K extends string>(key: Exclude<K, keyof ICustomGlobalSyncedMeta>): unknown;
   export function getSyncedMeta<K extends ExtractStringKeys<ICustomGlobalSyncedMeta>>(key: K): ICustomGlobalSyncedMeta[K] | undefined;
-  /** @deprecated */
+  /** @deprecated See {@link ICustomGlobalSyncedMeta} */
   export function getSyncedMeta<V extends any>(key: string): V | undefined;
 
   /**

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -955,7 +955,21 @@ declare module "alt-shared" {
   }
 
   /**
-   * Extend it by interface merging for use in alt.{@link getMeta}, alt.{@link setMeta}, etc.
+   * Extend it by interface merging for use in {@link getMeta alt.getMeta}, {@link setMeta alt.setMeta}, etc.
+   *
+   * @example
+   * ```
+   * declare module "alt-shared" {
+   *   // extending interface by interface merging
+   *   export interface ICustomGlobalMeta {
+   *     numberExample: number
+   *     stringExample: string
+   *   }
+   * }
+   *
+   * const value = alt.getMeta("numberExample") // return value: number | undefined
+   * alt.setMeta("stringExample", "value") // params key: "numberExample", value: string
+   * ```
    */
   export interface ICustomGlobalMeta {}
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -934,8 +934,12 @@ declare module "alt-shared" {
 
   /**
    * Gets a type of value for key from meta interface
+   *
+   * * T - meta interface
+   * * K - meta key
+   * * VDefault - default K (meta value) if key is missing in T (meta interface).
    */
-  type GetMetaKeyValue<T extends Record<any, any>, K> = K extends keyof T ? T[K] : unknown;
+  type GetMetaKeyValue<T extends Record<any, any>, K, VDefault = unknown> = K extends keyof T ? T[K] : VDefault;
 
   export class Vector3 {
     public readonly x: number;
@@ -1482,12 +1486,13 @@ declare module "alt-shared" {
    */
   export const debug: boolean;
 
+  // "V" generic overloads in get & set meta methods remain only for backward compatibility
+  // TODO: remove "V" generic overloads from all get & set meta methods (alt.getMeta, alt.Entity.getSyncedMeta, etc.)
   /**
    * Removes the specified key and the data connected to that specific key.
    *
    * @param key The key of the value to remove.
    */
-  // export function deleteMeta<K extends keyof StringOnlyKeys<ICustomGlobalMeta>>(key: K extends number ? never : K): void;
   export function deleteMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): void;
   export function deleteMeta(key: string): void;
 
@@ -1499,6 +1504,8 @@ declare module "alt-shared" {
    */
   export function getMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K): ICustomGlobalMeta[K] | undefined;
   export function getMeta(key: string): unknown;
+  /** @deprecated */
+  export function getMeta<V extends any>(key: string): V | undefined;
 
   /**
    * Determines whether contains the specified key.
@@ -1519,6 +1526,8 @@ declare module "alt-shared" {
    */
   export function setMeta<K extends string>(key: K, value: GetMetaKeyValue<ICustomGlobalMeta, K>): void;
   export function setMeta<K extends keyof ExtractStringKeys<ICustomGlobalMeta>>(key: K, value: ICustomGlobalMeta[K]): void;
+  /** @deprecated */
+  export function setMeta<V extends any, K extends string = string>(key: K, value: GetMetaKeyValue<ICustomGlobalMeta, K, V>): void;
 
   /**
    * Gets a value using the specified key.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -920,6 +920,11 @@ declare module "alt-shared" {
     readonly type: string;
   }
 
+  /**
+   * Extend it using interface merging for using in alt.{@link getMeta}, alt.{@link setMeta}, etc.
+   */
+  export interface ICustomGlobalMeta {}
+
   export class Vector3 {
     public readonly x: number;
 
@@ -1470,7 +1475,7 @@ declare module "alt-shared" {
    *
    * @param key The key of the value to remove.
    */
-  export function deleteMeta(key: string): void;
+  export function deleteMeta<K extends keyof ICustomGlobalMeta>(key: K): void;
 
   /**
    * Gets a value using the specified key.
@@ -1478,7 +1483,7 @@ declare module "alt-shared" {
    * @param key The key of the value to get.
    * @returns Dynamic value associated with the specified key or undefined if no data is present.
    */
-  export function getMeta<T = any>(key: string): T | undefined;
+  export function getMeta<K extends keyof ICustomGlobalMeta>(key: K): ICustomGlobalMeta[K] | undefined;
 
   /**
    * Determines whether contains the specified key.
@@ -1486,7 +1491,7 @@ declare module "alt-shared" {
    * @param key The key of the value to locate.
    * @returns True when element associated with the specified key is stored.
    */
-  export function hasMeta(key: string): boolean;
+  export function hasMeta<K extends keyof ICustomGlobalMeta>(key: K): boolean;
 
   /**
    * Stores the given value with the specified key.
@@ -1496,7 +1501,7 @@ declare module "alt-shared" {
    * @param key The key of the value to store.
    * @param value The value to store.
    */
-  export function setMeta<T = any>(key: string, value: T): void;
+  export function setMeta<K extends keyof ICustomGlobalMeta>(key: K, value: ICustomGlobalMeta[K]): void;
 
   /**
    * Gets a value using the specified key.


### PR DESCRIPTION
Now we need to pass generic parameter into meta methods every time, and there is no autocomplete for the meta keys in current solution, so its not very convenient.

I added empty interfaces for global meta, player, entity (currently) to be extended by users, which works just like the event functions. (e.g. `alt.on` with `alt.IClientEvent`)

Example usage
```ts
import * as alt from "alt-shared"

declare module "alt-shared" {
  export interface ICustomGlobalMeta {
    numberMeta: number
    stringMeta: string
    123: any
  }
}

const value /* number | undefined */ = alt.getMeta("numberMeta") // return type from ICustomGlobalMeta['numberMeta']
const unknown /* unknown */ = alt.getMeta("unknown")

// key: string
alt.deleteMeta("anyKey")
alt.hasMeta("anyKey")

// autocomplete keys: 'numberMeta' | 'stringMeta' from ICustomGlobalMeta
alt.deleteMeta("stringMeta")
alt.hasMeta("numberMeta")

alt.setMeta("stringMeta", "value") // ok stringMeta: string in ICustomGlobalMeta
alt.setMeta("stringMeta", 123) // error: value must be a string

alt.setMeta("anyKey", undefined) // ok value type is unknown
alt.setMeta(123, "anything") // error: key must be a string

// these overloads remains only for backward compatibility and are marked as deprecated
const genericValue /* null | undefined */ = alt.getMeta<null>("deprecated")
alt.setMeta<number>("deprecated", 123) // ok value: number
alt.setMeta<number>("deprecated", "str") // error: value must be a number
```