### PR TITLE
Add generic and union function overloads as an alternative to enums

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1747,7 +1747,8 @@ declare module "alt-client" {
   /**
    * Gets the current alt:V locale.
    */
-  export function getLocale(): string;
+  export function getLocale(): Locale;
+  export function getLocale(): `${Locale}`;
 
   /**
    * Gets the current milliseconds per game minute.
@@ -1763,6 +1764,7 @@ declare module "alt-client" {
    * @returns Permission state.
    */
   export function getPermissionState(permId: shared.Permission): PermissionState;
+  export function getPermissionState<T extends number, V extends number = PermissionState>(permId: T): V;
 
   /**
    * Gets a value of the specified statistic.
@@ -1770,6 +1772,7 @@ declare module "alt-client" {
    * @param statName Name of the statistic.
    */
   export function getStat(statName: StatName): number;
+  export function getStat(statName: `${StatName}`): number;
 
   /**
    * Returns state of console window.
@@ -1952,6 +1955,7 @@ declare module "alt-client" {
    * @param statName Name of the statistic.
    */
   export function resetStat(statName: StatName): void;
+  export function resetStat(statName: `${StatName}`): void;
 
   /**
    * Freezes the camera in place so it doesn't change position or rotation.
@@ -1971,6 +1975,7 @@ declare module "alt-client" {
    * @param state Config flag state.
    */
   export function setConfigFlag(flag: ConfigFlag, state: boolean): void;
+  export function setConfigFlag(flag: `${ConfigFlag}`, state: boolean): void;
 
   /**
    * Returns the state of the specified ped config flag of the local player.
@@ -1979,6 +1984,7 @@ declare module "alt-client" {
    * @returns State of the specified config flag.
    */
   export function getConfigFlag(flag: ConfigFlag): boolean;
+  export function getConfigFlag(flag: `${ConfigFlag}`): boolean;
 
   /**
    * Returns whether the specified config flag exists.
@@ -2017,6 +2023,7 @@ declare module "alt-client" {
    * @param value Value of the statistic you want to set.
    */
   export function setStat(statName: StatName, value: number): void;
+  export function setStat(statName: `${StatName}`, value: number): void;
 
   /**
    * Sets the current weather cycle.
@@ -2273,6 +2280,7 @@ declare module "alt-client" {
    * @param position Watermarkposition.
    */
   export function setWatermarkPosition(position: WatermarkPosition): void;
+  export function setWatermarkPosition<T extends number>(position: T): void;
 
   /**
    * Represents the current client ping.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -812,6 +812,7 @@ declare module "alt-server" {
     public setWeaponTintIndex(weaponHash: number, tintIndex: number): void;
 
     public setWeather(weatherType: WeatherType): void;
+    public setWeather<T extends number>(weatherType: T): void;
 
     /**
      * Spawns the player in the world.
@@ -1311,6 +1312,7 @@ declare module "alt-server" {
      * @returns The damage level of a bumper.
      */
     public getBumperDamageLevel(bumperId: VehicleBumper): VehicleBumperDamage;
+    public getBumperDamageLevel<T extends number, V extends number = VehicleBumperDamage>(bumperId: T): V;
     /**
      * Returns the damage status of a vehicle as a base64 string.
      *
@@ -1326,6 +1328,7 @@ declare module "alt-server" {
      * @returns The state of the door.
      */
     public getDoorState(doorId: VehicleDoor): VehicleDoorState;
+    public getDoorState<T extends number, V extends number = VehicleDoorState>(doorId: T): V;
     /**
      * Returns the state of a specific extra of a vehicle.
      *
@@ -1358,6 +1361,7 @@ declare module "alt-server" {
      * @returns The value of the mod type.
      */
     public getMod(modType: VehicleModType): number;
+    public getMod<T extends number>(modType: T): number;
     /**
      * Returns the amount of possible mod values for a specific mod type.
      *
@@ -1365,6 +1369,7 @@ declare module "alt-server" {
      * @returns The amount of possible mod values of a mod type.
      */
     public getModsCount(modType: VehicleModType): number;
+    public getModsCount<T extends number>(modType: T): number;
     /**
      * Returns the amount of bullet holes of a vehicle part.
      *
@@ -1372,6 +1377,7 @@ declare module "alt-server" {
      * @returns The amount of bullet holes of a vehicle part.
      */
     public getPartBulletHoles(partId: VehiclePart): number;
+    public getPartBulletHoles<T extends number>(partId: T): number;
     /**
      * Returns the damage level of a vehicle part.
      *
@@ -1379,6 +1385,7 @@ declare module "alt-server" {
      * @returns The damage level of a vehicle part.
      */
     public getPartDamageLevel(partId: VehiclePart): VehiclePartDamage;
+    public getPartDamageLevel<T extends number, V extends number = VehiclePartDamage>(partId: T): V;
     /**
      * Returns the script data of a vehicle as a base64 string.
      *
@@ -1477,6 +1484,7 @@ declare module "alt-server" {
      * @param level The damage level.
      */
     public setBumperDamageLevel(bumperId: VehicleBumper, level: VehicleBumperDamage): void;
+    public setBumperDamageLevel<T extends number, V extends number = VehicleBumperDamage>(bumperId: T, level: V): void;
     /**
      * Sets the damage status of a vehicle based on a base64 string.
      *
@@ -1492,6 +1500,7 @@ declare module "alt-server" {
      * @param state The state of the door.
      */
     public setDoorState(doorId: VehicleDoor, state: VehicleDoorState): void;
+    public setDoorState<T extends number, V extends number = VehicleDoorState>(doorId: T, state: V): void;
     /**
      * Sets the state of an extra of a vehicle.
      *
@@ -1531,6 +1540,7 @@ declare module "alt-server" {
      * @param modId The id of the mod.
      */
     public setMod(modType: VehicleModType, modId: number): void;
+    public setMod<T extends number>(modType: T, modId: number): void;
     /**
      * Applies bullet holes to a specific vehicle part.
      *
@@ -1538,6 +1548,7 @@ declare module "alt-server" {
      * @param count The amount of bullet holes.
      */
     public setPartBulletHoles(partId: VehiclePart, count: number): void;
+    public setPartBulletHoles<T extends number>(partId: T, count: number): void;
     /**
      * Sets the damage level of a vehicle part.
      *
@@ -1545,6 +1556,7 @@ declare module "alt-server" {
      * @param level The damage level.
      */
     public setPartDamageLevel(partId: VehiclePart, level: VehiclePartDamage): void;
+    public setPartDamageLevel<T extends number, V extends number = VehiclePartDamage>(partId: T, level: V): void;
     /**
      * Sets type of the rear wheels.
      *


### PR DESCRIPTION
TS:
In typescript builders such as esbuild or swc we can't use const enums because of the typescript isolated modules.
JS:
Since not all js users know what enums are and how to use them, here is autocomplete for methods, that accept string enums

This pr adds overloads that allow us to use our custom enums (instead of numeric enums) or literal strings (instead of string enums) in functions.

Example of use custom numeric enum (copy of the altv one):

![image](https://user-images.githubusercontent.com/54737754/159806796-4a787d77-af5d-4a07-a349-163ddb8679f9.png)
![image](https://user-images.githubusercontent.com/54737754/159806811-56ab291f-6c49-4cda-9201-59d3b083a800.png)
