### PR TITLE
 Do not allow to emit alt:V event name

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1930,6 +1930,26 @@ declare module "alt-client" {
   export function beginScaleformMovieMethodMinimap(methodName: string): boolean;
 
   /**
+   * Emits specified event across resources.
+   *
+   * @param eventName Name of the event.
+   * @param args Rest parameters for emit to send.
+   */
+  // Do not allow to emit alt:V event name
+  export function emit<K extends string>(eventName: Exclude<K, keyof IClientEvent>, ...args: any[]): void;
+
+  /**
+   * Emits specified event across resources.
+   *
+   * @param eventName Name of the event.
+   * @param args Rest parameters for emit to send.
+   *
+   * @remarks Works only from JS resource to JS resource
+   */
+  // Do not allow to emit alt:V event name
+  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IClientEvent>, ...args: any[]): void;
+
+  /**
    * Emits specified event to server.
    *
    * @param player Event is sent to specific player.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2196,6 +2196,26 @@ declare module "alt-server" {
   export function deleteSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomGlobalSyncedMeta>>(key: K): void;
 
   /**
+   * Emits specified event across resources.
+   *
+   * @param eventName Name of the event.
+   * @param args Rest parameters for emit to send.
+   */
+  // Do not allow to emit alt:V event name
+  export function emit<K extends string>(eventName: Exclude<K, keyof IServerEvent>, ...args: any[]): void;
+
+  /**
+   * Emits specified event across resources.
+   *
+   * @param eventName Name of the event.
+   * @param args Rest parameters for emit to send.
+   *
+   * @remarks Works only from JS resource to JS resource
+   */
+  // Do not allow to emit alt:V event name
+  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IServerEvent>, ...args: any[]): void;
+
+  /**
    * Emits specified event to specific client.
    *
    * @param player Event is sent to specific player.


### PR DESCRIPTION
This pr just adds small improvement (not fuckery like it was with meta) that restricts typescript users from emitting alt:V event name on client and server

its pretty much the same thing I did here: https://github.com/altmp/altv-types/pull/131