### PR TITLE
client|server|shared: Make return arrays read-only

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -333,8 +333,8 @@ declare module "alt-client" {
     readonly bailoutReason: string | null;
     readonly hitCount: number;
     readonly timestamp: number;
-    readonly children: Array<IProfileNode> | null;
-    readonly lineTicks: Array<ILineTick> | null;
+    readonly children: ReadonlyArray<IProfileNode> | null;
+    readonly lineTicks: ReadonlyArray<ILineTick> | null;
   }
 
   export interface ILineTick {
@@ -464,7 +464,7 @@ declare module "alt-client" {
     /**
      * @remarks This method has no effect if the {@link frontendPlay} property returns true.
      */
-    public getOutputs(): Array<Entity | number>;
+    public getOutputs(): ReadonlyArray<Entity | number>;
 
     public play(): void;
     public pause(): void;
@@ -543,7 +543,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: Array<Entity>;
+    public static readonly all: ReadonlyArray<Entity>;
 
     /** Entity unique id */
     public readonly id: number;
@@ -670,12 +670,12 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: Array<Player>;
+    public static readonly all: ReadonlyArray<Player>;
 
     /**
      * Array with all streamed in players.
      */
-    public static readonly streamedIn: Array<Player>;
+    public static readonly streamedIn: ReadonlyArray<Player>;
 
     /**
      * The local player instance.
@@ -699,7 +699,7 @@ declare module "alt-client" {
     /**
      * Current weapon components.
      */
-    public readonly currentWeaponComponents: Array<number>;
+    public readonly currentWeaponComponents: ReadonlyArray<number>;
 
     /**
      * Tint index for currently equipped weapon.
@@ -942,12 +942,12 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: Array<Vehicle>;
+    public static readonly all: ReadonlyArray<Vehicle>;
 
     /**
      * Array with all streamed in vehicles.
      */
-    public static readonly streamedIn: Array<Vehicle>;
+    public static readonly streamedIn: ReadonlyArray<Vehicle>;
 
     /**
      * Vehicle gear.
@@ -1662,7 +1662,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: Array<Blip>;
+    public static readonly all: ReadonlyArray<Blip>;
 
     public readonly scriptID: number;
 
@@ -2736,7 +2736,7 @@ declare module "alt-client" {
 
     public readonly ownerDocument: RmlDocument;
 
-    public readonly childNodes: Array<RmlElement>;
+    public readonly childNodes: ReadonlyArray<RmlElement>;
 
     public appendChild(child: RmlElement): void;
 
@@ -2752,7 +2752,7 @@ declare module "alt-client" {
 
     public hasClass(name: string): boolean;
 
-    public getClassList(): Array<string>;
+    public getClassList(): ReadonlyArray<string>;
 
     public addPseudoClass(name: string): boolean;
 
@@ -2760,7 +2760,7 @@ declare module "alt-client" {
 
     public hasPseudoClass(name: string): boolean;
 
-    public getPseudoClassList(): Array<string>;
+    public getPseudoClassList(): ReadonlyArray<string>;
 
     public setOffset(element: RmlElement, offset: shared.IVector2, fixed?: boolean): void;
 
@@ -2794,13 +2794,13 @@ declare module "alt-client" {
 
     public getElementByID(id: string): RmlElement | null;
 
-    public getElementsByTagName(tag: string): Array<RmlElement>;
+    public getElementsByTagName(tag: string): ReadonlyArray<RmlElement>;
 
-    public getElementsByClassName(className: string): Array<RmlElement>;
+    public getElementsByClassName(className: string): ReadonlyArray<RmlElement>;
 
     public querySelector(selector: string): RmlElement | null;
 
-    public querySelectorAll(selector: string): Array<RmlElement>;
+    public querySelectorAll(selector: string): ReadonlyArray<RmlElement>;
 
     public focus(): boolean;
 

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -347,7 +347,7 @@ declare module "alt-server" {
   export interface IWeapon {
     readonly hash: number;
     readonly tintIndex: number;
-    readonly components: Array<number>;
+    readonly components: ReadonlyArray<number>;
   }
 
   export interface IConnectionInfo {
@@ -482,7 +482,7 @@ declare module "alt-server" {
     readonly interiorColor: number;
     readonly dashboardColor: number;
     readonly hasAutoAttachTrailer: boolean;
-    readonly availableModkits: Array<boolean>;
+    readonly availableModkits: ReadonlyArray<boolean>;
     hasExtra(extraId: number): boolean;
     hasDefaultExtra(extraId: number): boolean;
   }
@@ -599,7 +599,7 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: Array<Entity>;
+    public static readonly all: ReadonlyArray<Entity>;
 
     /**
      * Internal identificator of the entity which is identical on both sides.
@@ -812,11 +812,11 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static all: Array<Player>;
+    public static readonly all: ReadonlyArray<Player>;
     public armour: number;
     public currentWeapon: number;
-    public readonly weapons: Array<IWeapon>;
-    public readonly currentWeaponComponents: Array<number>;
+    public readonly weapons: ReadonlyArray<IWeapon>;
+    public readonly currentWeaponComponents: ReadonlyArray<number>;
     public readonly currentWeaponTintIndex: number;
     public readonly entityAimOffset: shared.Vector3;
     public readonly entityAimingAt: Entity | null;
@@ -2188,7 +2188,7 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: Array<Blip>;
+    public static readonly all: ReadonlyArray<Blip>;
 
     public routeColor: shared.RGBA;
 
@@ -2403,7 +2403,7 @@ declare module "alt-server" {
     /** @deprecated See {@link ICustomVoiceChannelMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomVoiceChannelMeta, K, V>): void;
 
-    public readonly players: Array<Player>;
+    public readonly players: ReadonlyArray<Player>;
 
     public readonly playerCount: number;
   }

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1843,7 +1843,7 @@ declare module "alt-shared" {
    */
   export const isServer: boolean;
 
-  export function getAllResources(): Array<IResource>;
+  export function getAllResources(): ReadonlyArray<IResource>;
 
   export function time(timerName: string): void;
 
@@ -1859,13 +1859,13 @@ declare module "alt-shared" {
     public readonly name: string;
     public readonly main: string;
     public readonly exports: Record<string, any>;
-    public readonly dependencies: Array<string>;
-    public readonly dependants: Array<string>;
-    public readonly requiredPermissions: Array<Permission>;
-    public readonly optionalPermissions: Array<Permission>;
+    public readonly dependencies: ReadonlyArray<string>;
+    public readonly dependants: ReadonlyArray<string>;
+    public readonly requiredPermissions: ReadonlyArray<Permission>;
+    public readonly optionalPermissions: ReadonlyArray<Permission>;
 
     public static getByName(name: string): Resource | null;
-    public static readonly all: Array<Resource>;
+    public static readonly all: ReadonlyArray<Resource>;
     public static readonly current: Resource;
   }
 


### PR DESCRIPTION
Since users can now easily mutate arrays returned from the alt:V (possibly objects as well) that behavior can lead to possible confusion and bugs

![изображение](https://user-images.githubusercontent.com/54737754/171451120-3a026578-48c9-4eeb-a4f1-3239cd9be183.png)

![изображение](https://user-images.githubusercontent.com/54737754/171451137-f52dc334-f18e-4201-93f7-029ad73c46d8.png)
