### PR TITLE
Types: Add some descriptions, correct others

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -851,12 +851,12 @@ declare module "alt-client" {
     //public readonly isStealthy: boolean;
 
     /**
-     * Fordwarspeed of the player
+     * Forward speed of the player.
      */
     public readonly forwardSpeed: number;
 
     /**
-     * Strafespeed of the player
+     * Strafe speed of the player.
      */
     public readonly strafeSpeed: number;
 
@@ -1404,10 +1404,19 @@ declare module "alt-client" {
      */
     //public readonly manualEngineControl: boolean;
 
+    /**
+     * The vehicle's engine temperature.
+     */
     public engineTemperature: number;
 
+    /**
+     * The vehicle's fuel level.
+     */
     public fuelLevel: number;
 
+    /**
+     * The vehicle's oil level.
+     */
     public oilLevel: number;
 
     // normal meta

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -814,10 +814,15 @@ declare module "alt-server" {
     public readonly isInRagdoll: boolean;
     public readonly isAiming: boolean;
     public readonly isDead: boolean;
+
     /** @alpha */
     //public readonly isShooting: boolean;
     /** @alpha */
     //public readonly isJumping: boolean;
+
+    /**
+     * The player's state of weapon reloading.
+     */
     public readonly isReloading: boolean;
     /**
      * Position the player is currently aiming at.


### PR DESCRIPTION
Added missing descriptions in places where documentation/jsdoc was broken.

Example broken engineTemperature property:
![изображение](https://user-images.githubusercontent.com/54737754/180573425-cc8d6bac-bf33-4f72-8722-82ce4244d1a9.png)
https://docs.altv.mp/js/api/alt-client.Vehicle.html#_altmp_altv_types_alt_client_Vehicle_engineTemperature