### PR TITLE
shared: Fix alt.Utils exported classes

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2924,13 +2924,13 @@ declare module "alt-client" {
     public static drawText2dThisFrame(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
 
     /** @alpha */
-    public static drawText2d(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.EveryTick;
+    public static drawText2d(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
 
     /** @alpha */
     public static drawText3dThisFrame(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
 
     /** @alpha */
-    public static drawText3d(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.EveryTick;
+    public static drawText3d(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
 
     /**
      * Loads the map area at a certain position

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -2001,36 +2001,6 @@ declare module "alt-shared" {
     public static readonly current: Resource;
   }
 
-  class Timer {
-    public readonly id: number;
-
-    constructor(callback: () => void, ms: number, once: boolean);
-
-    public destroy(): void;
-  }
-
-  class Timeout extends Timer {
-    constructor(callback: () => void, ms: number);
-  }
-
-  class Interval extends Timer {
-    constructor(callback: () => void, ms: number);
-  }
-
-  class NextTick extends Timer {
-    constructor(callback: () => void);
-  }
-
-  class EveryTick extends Timer {
-    constructor(callback: () => void);
-  }
-
-  class ConsoleCommand {
-    constructor(name: string, callback: (...args: string[]) => void);
-
-    public destroy(): void;
-  }
-
   export class Utils {
     protected constructor();
 
@@ -2043,20 +2013,44 @@ declare module "alt-shared" {
      * @param timeout The maximum milliseconds to wait, otherwise promise will be rejected. Defaults to 2000.
      */
     public static waitFor(callback: () => boolean, timeout?: number): Promise<void>;
+  }
+  
+  export namespace Utils {
+    /** @alpha */
+    export class Timer {
+      public readonly id: number;
+  
+      constructor(callback: () => void, ms: number, once: boolean);
+  
+      public destroy(): void;
+    }
+    
+    /** @alpha */
+    export class Timeout extends Timer {
+      constructor(callback: () => void, ms: number);
+    }
+    
+    /** @alpha */
+    export class Interval extends Timer {
+      constructor(callback: () => void, ms: number);
+    }
+    
+    /** @alpha */
+    export class NextTick extends Timer {
+      constructor(callback: () => void);
+    }
 
     /** @alpha */
-    public static readonly Timer: typeof Timer;
-    /** @alpha */
-    public static readonly Timeout: typeof Timeout;
-    /** @alpha */
-    public static readonly Interval: typeof Interval;
-    /** @alpha */
-    public static readonly NextTick: typeof NextTick;
-    /** @alpha */
-    public static readonly EveryTick: typeof EveryTick;
+    export class EveryTick extends Timer {
+      constructor(callback: () => void);
+    }
 
     /** @alpha */
-    public static readonly ConsoleCommand: typeof ConsoleCommand;
+    export class ConsoleCommand {
+      constructor(name: string, callback: (...args: string[]) => void);
+  
+      public destroy(): void;
+    }
   }
 
   /**

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -2014,27 +2014,27 @@ declare module "alt-shared" {
      */
     public static waitFor(callback: () => boolean, timeout?: number): Promise<void>;
   }
-  
+
   export namespace Utils {
     /** @alpha */
     export class Timer {
       public readonly id: number;
-  
+
       constructor(callback: () => void, ms: number, once: boolean);
-  
+
       public destroy(): void;
     }
-    
+
     /** @alpha */
     export class Timeout extends Timer {
       constructor(callback: () => void, ms: number);
     }
-    
+
     /** @alpha */
     export class Interval extends Timer {
       constructor(callback: () => void, ms: number);
     }
-    
+
     /** @alpha */
     export class NextTick extends Timer {
       constructor(callback: () => void);
@@ -2048,7 +2048,7 @@ declare module "alt-shared" {
     /** @alpha */
     export class ConsoleCommand {
       constructor(name: string, callback: (...args: string[]) => void);
-  
+
       public destroy(): void;
     }
   }


### PR DESCRIPTION
For some reason typescript exported classes that were not even marked as exported from typings, now its fixed

![изображение](https://user-images.githubusercontent.com/54737754/189761761-26f4c9d4-96b2-446d-afe0-12c51ae20b5c.png)
