### PR TITLE
client|shared: refactor Utils

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2922,33 +2922,39 @@ declare module "alt-client" {
     public style: Record<string, string>;
   }
 
+  // Do not add anything here, add to the Utils namespace instead!
+  // (this class is here only for extending shared Utils class & namespace)
   export class Utils extends shared.Utils {
+    protected constructor();
+  }
+
+  export namespace Utils {
     /**
      * Loads a model into memory asynchronously, like {@link loadModelAsync} but more safely.
      *
      * @remarks If you can't load a specific model with this method, use {@link loadModelAsync} instead.
      */
-    public static requestModel(model: string | number, timeout?: number): Promise<void>;
+    export function requestModel(model: string | number, timeout?: number): Promise<void>;
 
-    public static requestAnimDict(animDict: string, timeout?: number): Promise<void>;
+    export function requestAnimDict(animDict: string, timeout?: number): Promise<void>;
 
-    public static requestAnimSet(animSet: string, timeout?: number): Promise<void>;
+    export function requestAnimSet(animSet: string, timeout?: number): Promise<void>;
 
-    public static requestClipSet(clipSet: string, timeout?: number): Promise<void>;
+    export function requestClipSet(clipSet: string, timeout?: number): Promise<void>;
 
-    public static requestCutscene(cutsceneName: string, flags: string | number, timeout?: number): Promise<void>;
-
-    /** @alpha */
-    public static drawText2dThisFrame(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
+    export function requestCutscene(cutsceneName: string, flags: string | number, timeout?: number): Promise<void>;
 
     /** @alpha */
-    public static drawText2d(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
+    export function drawText2dThisFrame(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
 
     /** @alpha */
-    public static drawText3dThisFrame(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
+    export function drawText2d(text: string, pos2d?: shared.IVector2, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
 
     /** @alpha */
-    public static drawText3d(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
+    export function drawText3dThisFrame(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): void;
+
+    /** @alpha */
+    export function drawText3d(text: string, pos3d?: shared.IVector3, font?: GameFont, scale?: number, color?: shared.RGBA, outline?: boolean, dropShadow?: boolean): shared.Utils.EveryTick;
 
     /**
      * Loads the map area at a certain position
@@ -2962,10 +2968,9 @@ declare module "alt-client" {
      *
      * @alpha
      */
-    public static loadMapArea(pos: shared.IVector3, radius?: number, timeout?: number): Promise<void>;
-  }
+    export function loadMapArea(pos: shared.IVector3, radius?: number, timeout?: number): Promise<void>;
 
-  export namespace Utils {
+    /** @alpha */
     export class Keybind {
       /**
        * Binds a callback to a specific key or multiple keys.
@@ -2982,12 +2987,12 @@ declare module "alt-client" {
        * })
        * ```
        *
-       * @alpha
        */
       constructor(keyCode: shared.KeyCode | Array<shared.KeyCode>, callback: () => void, eventType?: "keyup" | "keydown");
       public destroy(): void;
     }
 
+    /** @alpha */
     export class Marker {
       constructor(pos: shared.IVector3, options?: IMarkerOptions);
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -2130,10 +2130,14 @@ declare module "alt-shared" {
     public static readonly current: Resource;
   }
 
+  // Do not add anything here, add to the Utils namespace instead!
+  // (this class is only here to be extended by client and server)
   export class Utils {
     protected constructor();
+  }
 
-    public static wait(timeout: number): Promise<void>;
+  export namespace Utils {
+    export function wait(timeout: number): Promise<void>;
 
     /**
      * Waits for the callback to return true, otherwise the promise will be rejected after timeout
@@ -2141,10 +2145,8 @@ declare module "alt-shared" {
      * @param callback If callback returns true it resolves promise.
      * @param timeout The maximum milliseconds to wait, otherwise promise will be rejected. Defaults to 2000.
      */
-    public static waitFor(callback: () => boolean, timeout?: number): Promise<void>;
-  }
+    export function waitFor(callback: () => boolean, timeout?: number): Promise<void>;
 
-  export namespace Utils {
     /** @alpha */
     export class Timer {
       public readonly id: number;


### PR DESCRIPTION
Moved everything from Utils classes to namespaces so that in the future you don't have to think about where to add a function or class.

Also I thought about deleting Utils classes completely, but then another problem appears with extending `shared.Utils`, it seems namespace can't be extended by another namespace