### PR TITLE
shared|client|server: Fix generic event functions

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2339,6 +2339,24 @@ declare module "alt-client" {
   export function once<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IClientEvent, K, (...args: any[]) => void, never>): void;
 
   /**
+   * Subscribes to all events with the specified listener.
+   *
+   * @remarks Listener will be only called for user-created events.
+   *
+   * @param listener Listener that should be added.
+   */
+  export function on(listener: (eventName: string, ...args: any[]) => void): void;
+
+  /**
+   * Unsubscribes from all user-created events with the specified listener.
+   *
+   * @remarks Listener should be of the same reference as when event was subscribed to.
+   *
+   * @param listener Listener that should be removed.
+   */
+  export function off(listener: (eventName: string, ...args: any[]) => void): void;
+
+  /**
    * Subscribes to a server event with the specified listener.
    *
    * @param eventName Name of the event.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2689,6 +2689,24 @@ declare module "alt-server" {
   export function once<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IServerEvent, K, (...args: any[]) => void, never>): void;
 
   /**
+   * Subscribes to all events with the specified listener.
+   *
+   * @remarks Listener will be only called for user-created events.
+   *
+   * @param listener Listener that should be added.
+   */
+  export function on(listener: (eventName: string, ...args: any[]) => void): void;
+
+  /**
+   * Unsubscribes from all user-created events with the specified listener.
+   *
+   * @remarks Listener should be of the same reference as when event was subscribed to.
+   *
+   * @param listener Listener that should be removed.
+   */
+  export function off(listener: (eventName: string, ...args: any[]) => void): void;
+
+  /**
    * Subscribes to a client event with the specified listener.
    *
    * @param eventName Name of the event.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -2116,6 +2116,15 @@ declare module "alt-shared" {
   export function once(listener: (eventName: string, ...args: any[]) => void): void;
 
   /**
+   * Unsubscribes from all user-created events with the specified listener.
+   *
+   * @remarks Listener should be of the same reference as when event was subscribed to.
+   *
+   * @param listener Listener that should be removed.
+   */
+  export function off(listener: (eventName: string, ...args: any[]) => void): void;
+
+  /**
    * Schedules execution of handler in specified intervals.
    *
    * @param handler Handler that should be scheduled for execution.


### PR DESCRIPTION
Copy-pasted alt.on & alt.off generic-event overloads from shared to client & server because typescript doesnt work other way