### PR TITLE
Remove destroyed base object emit info

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2144,8 +2144,6 @@ declare module "alt-client" {
   /**
    * Emits specified event across resources.
    *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
-   *
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
@@ -2165,8 +2163,6 @@ declare module "alt-client" {
 
   /**
    * Emits specified event to server.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
    *
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -923,8 +923,6 @@ declare module "alt-server" {
     /**
      * Emits specified event to client.
      *
-     * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
-     *
      * @param eventName Name of the event.
      * @param args Rest parameters for emit to send.
      */
@@ -2561,8 +2559,6 @@ declare module "alt-server" {
   /**
    * Emits specified event across resources.
    *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
-   *
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
@@ -2583,8 +2579,6 @@ declare module "alt-server" {
   /**
    * Emits specified event to specific client.
    *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
-   *
    * @param player Event is sent to specific player.
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
@@ -2593,8 +2587,6 @@ declare module "alt-server" {
 
   /**
    * Emits specified event to specific client.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
    *
    * @param player Event is sent to every player.
    * @param eventName Name of the event.
@@ -2606,8 +2598,6 @@ declare module "alt-server" {
 
   /**
    * Emits specified event to specific clients.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
    *
    * @param player Event is sent to every player in array.
    * @param eventName Name of the event.
@@ -2646,8 +2636,6 @@ declare module "alt-server" {
 
   /**
    * Emits specified event to all clients.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about sending destroyed entities.
    *
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
@@ -2715,8 +2703,6 @@ declare module "alt-server" {
   /**
    * Subscribes to a custom server event with the specified listener.
    *
-   * @remarks See {@link "alt-shared".emit} for more information about receiving destroyed entities
-   *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
@@ -2733,8 +2719,6 @@ declare module "alt-server" {
 
   /**
    * Subscribes to a custom server event with the specified listener, which only triggers once.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about receiving destroyed entities
    *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
@@ -2781,8 +2765,6 @@ declare module "alt-server" {
   /**
    * Subscribes to all client events with the specified listener.
    *
-   * @remarks See {@link "alt-shared".emit} for more information about receiving destroyed entities
-   *
    * @remarks Listener will be only called for user-created events.
    *
    * @param listener Listener that should be added.
@@ -2791,8 +2773,6 @@ declare module "alt-server" {
 
   /**
    * Subscribes to a client event with the specified listener, which only triggers once.
-   *
-   * @remarks See {@link "alt-shared".emit} for more information about receiving destroyed entities
    *
    * @param eventName Name of the event.
    * @param listener Listener that should be added.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -2008,23 +2008,6 @@ declare module "alt-shared" {
   /**
    * Emits specified event across resources.
    *
-   * @remarks Keep in mind that sending invalid (destroyed) BaseObject instance
-   * (for example vehicle, player, colshape, etc.)
-   * results in sending a null value.
-   *
-   * *Note:* this does not apply to [raw events](https://docs.altv.mp/js/articles/events/index.html#raw-events).
-   *
-   * @example
-   * ```js
-   * alt.on('test', (vehicle) =>
-   *   alt.log('received vehicle:', vehicle) // vehicle object will be null here
-   * );
-   *
-   * const vehicle = new alt.Vehicle('sultan', 0, 0, 0, 0, 0, 0);
-   * vehicle.destroy(); // makes vehicle object invalid
-   * alt.emit('test', vehicle); // sends vehicle object as null and throws error
-   * ```
-   *
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */


### PR DESCRIPTION
Since this is no longer the case, event with destroyed base object simply won't be sent