### PR TITLE
technical: Server: Implement getter & setter for model of entity and …

### DIFF
--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -741,10 +741,9 @@ declare module "alt-server" {
 
     /**
      * Entity model hash.
-     *
-     * @remarks Only setter accepts string or number as input, getter returns value as number.
      */
-    public model: number | string;
+    public get model(): number;
+    public set model(model: number | string);
 
     /**
      * Entity rotation.
@@ -1482,9 +1481,9 @@ declare module "alt-server" {
      *     console.log('This vehicle is not an infernus.');
      * }
      * ```
-     * @remarks Only setter accepts string or number as input, getter returns value as number.
+     * @remarks Vehicle doesn't provide a setter.
      */
-    public readonly model: number | string;
+    public get model(): number;
 
     /**
      * Gets or sets the active radio station.


### PR DESCRIPTION
…getter for vehicle

Problem:
Since setters of model allow for number or string, providing type safety to declarations must be ensured when getting the model by specfically stating `player.model as number` every time.

Example:
```
const map = new Map<number, any>(); // Maps player model hash to something

if (map.has(p.model)) {} // Will throw "Argument of type 'string | number' is not assignable to parameter of type 'number'.
  Type 'string' is not assignable to type 'number'.ts(2345)" and must be circumvented by:

if (map.has(p.model as number)) {}
```

Getter and setter approach resolves this issue.
