### PR TITLE
Custom Event Support for All Emit Types

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -515,6 +515,40 @@ declare module "alt-client" {
    */
   export interface ICustomVehicleMeta extends ICustomEntityMeta {}
 
+  /**
+   * Extend `alt.emit` auto-completion by merging interfaces for use with `alt.emit`.
+   * 
+   * @example
+   * ```ts
+   * declare module 'alt-client' {
+   *    interface ICustomEmitEvent {
+   *        myEvent: (arg1: string, arg2: { key: string, value: number })
+   *    }
+   * }
+   * ```
+   *
+   * @export
+   * @interface ICustomEmitEvent
+   */
+  export interface ICustomEmitEvent {}
+
+  /**
+   * Extend `alt.emitServer` auto-completion by merging interfaces for use with `alt.emitServer`.
+   * 
+   * @example
+   * ```ts
+   * declare module 'alt-client' {
+   *    interface ICustomEmitServerEvent {
+   *        myEvent: (arg1: string, arg2: { key: string, value: number })
+   *    }
+   * }
+   * ```
+   *
+   * @export
+   * @interface ICustomEmitServerEvent
+   */
+  export interface ICustomEmitServerEvent {}
+
   export interface IMarkerOptions {
     type?: number;
     dir?: shared.IVector3;
@@ -2598,7 +2632,8 @@ declare module "alt-client" {
    * @param args Rest parameters for emit to send.
    */
   // Do not allow to emit alt:V event name
-  export function emit<K extends string>(eventName: Exclude<K, keyof IClientEvent>, ...args: any[]): void;
+  export function emit<K extends keyof ICustomEmitEvent>(eventName: K, ...args: Parameters<ICustomEmitEvent[K]>): void;
+  export function emit<K extends string>(eventName: Exclude<K, keyof IClientEvent> & Exclude<K, keyof ICustomEmitEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event across resources.
@@ -2609,7 +2644,8 @@ declare module "alt-client" {
    * @remarks Works only from JS resource to JS resource
    */
   // Do not allow to emit alt:V event name
-  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IClientEvent>, ...args: any[]): void;
+  export function emitRaw<K extends keyof ICustomEmitEvent>(eventName: K, ...args: Parameters<ICustomEmitEvent[K]>): void;
+  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IClientEvent> & Exclude<K, keyof ICustomEmitEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to server.
@@ -2617,7 +2653,8 @@ declare module "alt-client" {
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
-  export function emitServer(eventName: string, ...args: any[]): void;
+  export function emitServer<K extends keyof ICustomEmitServerEvent>(eventName: K, ...args: Parameters<ICustomEmitServerEvent[K]>): void;
+  export function emitServer<K extends string>(eventName: Exclude<K, keyof ICustomEmitServerEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to server.
@@ -2627,7 +2664,8 @@ declare module "alt-client" {
    *
    * @remarks Works only from JS (Client) to JS (Server)
    */
-  export function emitServerRaw(eventName: string, ...args: any[]): void;
+  export function emitServerRaw<K extends keyof ICustomEmitServerEvent>(eventName: K, ...args: Parameters<ICustomEmitServerEvent[K]>): void;
+  export function emitServerRaw<K extends string>(eventName: Exclude<K, keyof ICustomEmitServerEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to server.
@@ -2639,7 +2677,8 @@ declare module "alt-client" {
    *
    * @alpha
    */
-  export function emitServerUnreliable(eventName: string, ...args: any[]): void;
+  export function emitServerUnreliable<K extends keyof ICustomEmitServerEvent>(eventName: K, ...args: Parameters<ICustomEmitServerEvent[K]>): void;
+  export function emitServerUnreliable<K extends string>(eventName: Exclude<K, keyof ICustomEmitServerEvent>, ...args: any[]): void;
 
   /**
    * Returns whether the game controls are currently enabled.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -511,6 +511,41 @@ declare module "alt-server" {
   export interface ICustomVehicleMeta extends ICustomEntityMeta {}
 
   /**
+   * Extend `alt.emit` auto-completion by merging interfaces for use with `alt.emit`.
+   * 
+   * @example
+    * ```ts
+    * declare module 'alt-server' {
+    *    interface ICustomEmitEvent {
+    *        myEvent: (arg1: string, arg2: { key: string, value: number })
+    *    }
+    * }
+    * ```
+    *
+    * @export
+    * @interface ICustomEmitEvent
+    */
+  export interface ICustomEmitEvent {}
+ 
+  /**
+    * Extend `alt.emitClient` & `player.emit` auto-completion by merging interfaces
+    * 
+    * @example
+    * ```ts
+    * declare module 'alt-server' {
+    *    interface ICustomEmitClientEvent {
+    *        myEvent: (arg1: string, arg2: { key: string, value: number })
+    *    }
+    * }
+    * ```
+    *
+    * @export
+    * @interface ICustomEmitClientEvent
+    */
+  export interface ICustomEmitClientEvent {}
+
+
+  /**
    * Documentation: https://docs.altv.mp/articles/configs/server.html
    */
   export interface IServerConfig {
@@ -1050,15 +1085,18 @@ declare module "alt-server" {
      * @param eventName Name of the event.
      * @param args Rest parameters for emit to send.
      */
-    public emit(eventName: string, ...args: any[]): void;
 
+    public emit<K extends keyof ICustomEmitClientEvent>(eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+    public emit<K extends string>(eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
+      
     /**
      * Emits specified event to client, but faster as {@link Player.emit}.
      *
      * @param eventName Name of the event.
      * @param args Rest parameters for emit to send.
      */
-    public emitRaw(eventName: string, ...args: any[]): void;
+    public emitRaw<K extends keyof ICustomEmitClientEvent>(eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+    public emitRaw<K extends string>(eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
     public addWeaponComponent(weaponHash: number, component: number): void;
 
@@ -2854,7 +2892,8 @@ declare module "alt-server" {
    * @param args Rest parameters for emit to send.
    */
   // Do not allow to emit alt:V event name
-  export function emit<K extends string>(eventName: Exclude<K, keyof IServerEvent>, ...args: any[]): void;
+  export function emit<K extends keyof ICustomEmitEvent>(eventName: K, ...args: Parameters<ICustomEmitEvent[K]>): void;
+  export function emit<K extends string>(eventName: Exclude<K, keyof IServerEvent> & Exclude<K, keyof ICustomEmitEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event across resources.
@@ -2865,48 +2904,33 @@ declare module "alt-server" {
    * @remarks Works only from JS resource to JS resource
    */
   // Do not allow to emit alt:V event name
-  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IServerEvent>, ...args: any[]): void;
+  export function emitRaw<K extends keyof ICustomEmitEvent>(eventName: K, ...args: Parameters<ICustomEmitEvent[K]>): void;
+  export function emitRaw<K extends string>(eventName: Exclude<K, keyof IServerEvent> & Exclude<K, keyof ICustomEmitEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to specific client.
    *
-   * @param player Event is sent to specific player.
+   * @param player Event is sent to specific player or players.
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
-  export function emitClient(player: Player, eventName: string, ...args: any[]): void;
-
-  /**
-   * Emits specified event to specific clients.
-   *
-   * @param player Event is sent to every player in array.
-   * @param eventName Name of the event.
-   * @param args Rest parameters for emit to send.
-   */
-  export function emitClient(player: Player[], eventName: string, ...args: any[]): void;
-
-  /**
-   * Emits specified event to specific clients.
-   *
-   * @param player Event is sent to every player in array.
-   * @param eventName Name of the event.
-   * @param args Rest parameters for emit to send.
-   */
-  export function emitClientRaw(player: Player[], eventName: string, ...args: any[]): void;
+  export function emitClient<K extends keyof ICustomEmitClientEvent>(player: Player | Player[], eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitClient<K extends string>(player: Player | Player[], eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to specific client.
    *
-   * @param player Event is sent to specific player.
+   * @param player Event is sent to specific player or players.
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
-  export function emitClientRaw(player: Player, eventName: string, ...args: any[]): void;
+  export function emitClientRaw<K extends keyof ICustomEmitClientEvent>(player: Player | Player[], eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitClientRaw<K extends string>(player: Player | Player[], eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to specific client.
    *
-   * @param player Event is sent to specific player.
+   * @param player Event is sent to specific player or players.
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    *
@@ -2914,20 +2938,8 @@ declare module "alt-server" {
    *
    * @alpha
    */
-  export function emitClientUnreliable(player: Player, eventName: string, ...args: any[]): void;
-
-  /**
-   * Emits specified event to specific clients.
-   *
-   * @param player Event is sent to every player in array.
-   * @param eventName Name of the event.
-   * @param args Rest parameters for emit to send.
-   *
-   * @remarks Unreliable event should be used when you don't need to be sure that event will be received by client.
-   *
-   * @alpha
-   */
-  export function emitClientUnreliable(player: Player[], eventName: string, ...args: any[]): void;
+  export function emitClientUnreliable<K extends keyof ICustomEmitClientEvent>(player: Player | Player[], eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitClientUnreliable<K extends string>(player: Player | Player[], eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to all clients.
@@ -2935,7 +2947,8 @@ declare module "alt-server" {
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
-  export function emitAllClients(eventName: string, ...args: any[]): void;
+  export function emitAllClients<K extends keyof ICustomEmitClientEvent>(eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitAllClients<K extends string>(eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to all clients.
@@ -2943,7 +2956,8 @@ declare module "alt-server" {
    * @param eventName Name of the event.
    * @param args Rest parameters for emit to send.
    */
-  export function emitAllClientsRaw(eventName: string, ...args: any[]): void;
+  export function emitAllClientsRaw<K extends keyof ICustomEmitClientEvent>(eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitAllClientsRaw<K extends string>(eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Emits specified event to all clients.
@@ -2955,7 +2969,8 @@ declare module "alt-server" {
    *
    * @alpha
    */
-  export function emitAllClientsUnreliable(eventName: string, ...args: any[]): void;
+  export function emitAllClientsUnreliable<K extends keyof ICustomEmitClientEvent>(eventName: K, ...args: Parameters<ICustomEmitClientEvent[K]>): void;
+  export function emitAllClientsUnreliable<K extends string>(eventName: Exclude<K, keyof ICustomEmitClientEvent>, ...args: any[]): void;
 
   /**
    * Change the server password at runtime.


### PR DESCRIPTION
## Server Example + Verification

```ts
import * as alt from 'alt-server';

declare module 'alt-server' {
    interface ICustomEmitEvent {
        test: (value1: string) => void;
    }

    interface ICustomEmitClientEvent {
        test: (value1: string) => void;
    }
}

alt.on('playerConnect', (player) => {
    alt.emit('playerConnect'); // invalid

    // emit
    alt.emit('hello', 'whatever', 5, {}); // valid

    alt.emit('test', 5); // invalid
    alt.emit('test', 'valid'); // valid

    // emitRaw
    alt.emitRaw('hello', 'whatever', 5, {}); // valid

    alt.emitRaw('test', 5); // invalid
    alt.emitRaw('test', 'valid'); // valid

    // player.emit
    player.emit('whatever', 'hi', 5, {}); // valid

    player.emit('test', 5); // invalid
    player.emit('test', 'valid'); // valid;

    // player.emitRaw
    player.emitRaw('whatever', 'hi', 5, {}); // valid

    player.emitRaw('test', 5); // invalid
    player.emitRaw('test', 'valid'); // valid;

    // emitClient
    alt.emitClient(player, 'whatever', 'hi', 5, {}); // valid
    alt.emitClient([player], 'whatever', 'hi', 5, {}); // valid

    alt.emitClient(player, 'test', 5); // invalid
    alt.emitClient(player, 'test', 'valid'); // valid

    alt.emitClient([player], 'test', 5); // invalid
    alt.emitClient([player], 'test', 'hi'); // valid

    // emitClientRaw
    alt.emitClientRaw(player, 'whatever', 'hi', 5, {}); // valid
    alt.emitClientRaw([player], 'whatever', 'hi', 5, {}); // valid

    alt.emitClientRaw(player, 'test', 5); // invalid
    alt.emitClientRaw(player, 'test', 'valid'); // valid

    alt.emitClientRaw([player], 'test', 5); // invalid
    alt.emitClientRaw([player], 'test', 'valid'); // valid

    // emitClientUnreliable
    alt.emitClientUnreliable(player, 'whatever', 'hi', 5, {}); // valid;
    alt.emitClientUnreliable([player], 'whatever', 'hi', 5, {}); // valid;

    alt.emitClientUnreliable(player, 'test', 5); // invalid
    alt.emitClientUnreliable(player, 'test', 'valid'); // valid

    alt.emitClientUnreliable([player], 'test', 5); // invalid
    alt.emitClientUnreliable([player], 'test', 'valid'); // valid

    // emitAllClients
    alt.emitAllClients('whatever', 'hi', 5, {}); // valid;

    alt.emitAllClients('test', 5); // invalid;
    alt.emitAllClients('test', 'valid'); // valid;

    // emitAllClientsRaw
    alt.emitAllClientsRaw('whatever', 'hi', 5, {}); // valid;

    alt.emitAllClientsRaw('test', 5); // invalid;
    alt.emitAllClientsRaw('test', 'valid'); // valid;

    // emitAllClientsUnreliable
    alt.emitAllClientsUnreliable('whatever', 'hi', 5, {}); // valid;

    alt.emitAllClientsUnreliable('test', 5); // invalid;
    alt.emitAllClientsUnreliable('test', 'valid'); // valid;
});
```

## Client
```ts
import * as alt from 'alt-client';

declare module 'alt-client' {
    interface ICustomEmitEvent {
        testing: (arg1: string) => void;
    }

    interface ICustomEmitServerEvent {
        testing: (arg1: string) => void;
    }
}

// alt.emit
alt.emit('disconnect'); // invalid

alt.emit('hello', 'whatever', 5, {}); // valid

alt.emit('testing', 5); // invalid
alt.emit('testing', 'valid');

// alt.emitServer
alt.emitServer('hello', 'whatever', 5, {}); // valid

alt.emitServer('testing', 5); // invalid
alt.emitServer('testing', 'valid'); // invalid

// alt.emitServerRaw
alt.emitServerRaw('hello', 'whatever', 5, {}); // valid

alt.emitServerRaw('testing', 5); // invalid
alt.emitServerRaw('testing', 'valid'); // invalid

// alt.emitServerUnreliable
alt.emitServerUnreliable('hello', 'whatever', 5, {}); // valid

alt.emitServerUnreliable('testing', 5); // invalid
alt.emitServerUnreliable('testing', 'valid'); // invalid
```
