### PR TITLE
client|server: Fix on, once, off

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2808,18 +2808,8 @@ declare module "alt-client" {
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
-  export function on<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function on<K extends keyof IClientEvent>(eventName: K, listener: IClientEvent[K]): void;
+  export function on<K extends keyof IClientEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IClientEvent, ICustomEmitEvent, K>) => void): void;
   export function on<K extends string>(eventName: Exclude<K, keyof IClientEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-
-  /**
-   * Subscribes to a custom client event with the specified listener.
-   *
-   * @param eventName Name of the event.
-   * @param listener Listener that should be added.
-   */
-  // Do not allow any function to subscribe to the alt:V event
-  export function on<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IClientEvent, K, (...args: any[]) => void, never>): void;
 
   /**
    * Subscribes to a client event with the specified listener, which only triggers once.
@@ -2827,27 +2817,8 @@ declare module "alt-client" {
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
-  export function once<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function once<K extends keyof IClientEvent>(eventName: K, listener: IClientEvent[K]): void;
+  export function once<K extends keyof IClientEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IClientEvent, ICustomEmitEvent, K>) => void): void;
   export function once<K extends string>(eventName: Exclude<K, keyof IClientEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-
-  /**
-   * Subscribes to a custom client event with the specified listener, which only triggers once.
-   *
-   * @param eventName Name of the event.
-   * @param listener Listener that should be added.
-   */
-  // Do not allow any function to subscribe to the alt:V event
-  export function once<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IClientEvent, K, (...args: any[]) => void, never>): void;
-
-  /**
-   * Subscribes to all events with the specified listener.
-   *
-   * @remarks Listener will be only called for user-created events.
-   *
-   * @param listener Listener that should be added.
-   */
-  export function on(listener: (eventName: string, ...args: any[]) => void): void;
 
   /**
    * Unsubscribes from a event with the specified listener.
@@ -2857,10 +2828,8 @@ declare module "alt-client" {
    * @param eventName Name of the event.
    * @param listener Listener that should be removed.
    */
-  export function off<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function off<K extends keyof IClientEvent>(eventName: K, listener: IClientEvent[K]): void;
+  export function off<K extends keyof IClientEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IClientEvent, ICustomEmitEvent, K>) => void): void;
   export function off<K extends string>(eventName: Exclude<K, keyof IClientEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-  export function off(listener: (eventName: string, ...args: any[]) => void): void;
 
   /**
    * Subscribes to a server event with the specified listener.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -3002,18 +3002,8 @@ declare module "alt-server" {
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
-  export function on<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function on<K extends keyof IServerEvent>(eventName: K, listener: IServerEvent[K]): void;
+  export function on<K extends keyof IServerEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IServerEvent, ICustomEmitEvent, K>) => void): void;
   export function on<K extends string>(eventName: Exclude<K, keyof IServerEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-
-  /**
-   * Subscribes to a custom server event with the specified listener.
-   *
-   * @param eventName Name of the event.
-   * @param listener Listener that should be added.
-   */
-  // Do not allow any function to subscribe to the alt:V event
-  export function on<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IServerEvent, K, (...args: any[]) => void, never>): void;
 
   /**
    * Subscribes to a server event with the specified listener, which only triggers once.
@@ -3021,27 +3011,8 @@ declare module "alt-server" {
    * @param eventName Name of the event.
    * @param listener Listener that should be added.
    */
-  export function once<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function once<K extends keyof IServerEvent>(eventName: K, listener: IServerEvent[K]): void;
+  export function once<K extends keyof IServerEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IServerEvent, ICustomEmitEvent, K>) => void): void;
   export function once<K extends string>(eventName: Exclude<K, keyof IServerEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-
-  /**
-   * Subscribes to a custom server event with the specified listener, which only triggers once.
-   *
-   * @param eventName Name of the event.
-   * @param listener Listener that should be added.
-   */
-  // Do not allow any function to subscribe to the alt:V event
-  export function once<K extends string>(eventName: K, listener: shared.InterfaceValueByKey<IServerEvent, K, (...args: any[]) => void, never>): void;
-
-  /**
-   * Subscribes to all events with the specified listener.
-   *
-   * @remarks Listener will be only called for user-created events.
-   *
-   * @param listener Listener that should be added.
-   */
-  export function on(listener: (eventName: string, ...args: any[]) => void): void;
 
   /**
    * Unsubscribes from a event with the specified listener.
@@ -3051,10 +3022,8 @@ declare module "alt-server" {
    * @param eventName Name of the event.
    * @param listener Listener that should be removed.
    */
-  export function off<K extends keyof ICustomEmitEvent>(eventName: K, listener: (...args: Parameters<ICustomEmitEvent[K]>) => void): void;
-  export function off<K extends keyof IServerEvent>(eventName: K, listener: IServerEvent[K]): void;
+  export function off<K extends keyof IServerEvent | keyof ICustomEmitEvent>(eventName: K, listener: (...args: shared.EventParameters<IServerEvent, ICustomEmitEvent, K>) => void): void;
   export function off<K extends string>(eventName: Exclude<K, keyof IServerEvent | keyof ICustomEmitEvent>, listener: (...args: any[]) => void): void;
-  export function off(listener: (eventName: string, ...args: any[]) => void): void;
 
   /**
    * Subscribes to a client event with the specified listener.

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1712,6 +1712,29 @@ declare module "alt-shared" {
     [K in keyof TInterface as Extract<K, string>]: TInterface[K];
   };
 
+  /**
+   * This is an internal utility type and you probably don't need it
+   *
+   * Returns parameters of either built-in alt:V event (`TAltInterface`) or custom event (`TCustomInterface`) by the given `TEventName`
+   *
+   * @hidden
+   */
+  // prettier-ignore
+  export type EventParameters<
+    TAltInterface extends Record<any, any>,
+    TCustomInterface extends Record<any, any>,
+    TEventName extends keyof TAltInterface | keyof TCustomInterface,
+  > = (
+    Parameters<TEventName extends keyof TAltInterface
+      ? TAltInterface[TEventName]
+      : (
+        TEventName extends keyof TCustomInterface
+        ? TCustomInterface[TEventName]
+        : never
+      )
+    >
+  );
+
   export interface IVector2 {
     readonly x: number;
     readonly y: number;


### PR DESCRIPTION
Fixes built-it & custom event name collision from happening:
(and cleans up `on`, `once`, `off` overloads a bit)

![изображение](https://github.com/altmp/altv-types/assets/54737754/a22453cc-4d23-4776-a108-661aaf2b0d57)

Does not break autocomplete of built-in and custom events:

![изображение](https://github.com/altmp/altv-types/assets/54737754/435d2b9e-48e1-4a56-af66-76626c633a96)

# Tests

## Server

```ts
import * as alt from 'alt-server'

declare module 'alt-server' {
    interface ICustomEmitEvent {
        playerConnect: (impossible: string) => void
        test: (possible: string) => void
    }
}

alt.on("playerConnect", (player) => {}) // player: Player, valid
alt.on("playerConnect", (impossible: string) => {}) // now this is invalid
alt.on("playerConnect", (impossibleToo: number) => {}) // invalid

alt.once("playerConnect", (player) => {}) // player: Player, valid
alt.once("playerConnect", (impossible: string) => {}) // now this is invalid
alt.once("playerConnect", (impossibleToo: number) => {}) // invalid

alt.off("playerConnect", (player) => {}) // player: Player, valid
alt.off("playerConnect", (impossible: string) => {}) // now this is invalid
alt.off("playerConnect", (impossibleToo: number) => {}) // invalid

alt.on("test", (adawdawdw: number) => {}) // invalid
alt.once("test", (adawdawdw: number) => {}) // invalid
alt.off("test", (adawdawdw: number) => {}) // invalid

alt.on("awdawd", (adawdawdw: number) => {}) // valid
alt.once("awdawd", (adawdawdw: number) => {}) // valid
alt.off("awdawd", (adawdawdw: number) => {}) // valid
```

## Client
```ts
import * as alt from 'alt-client'

declare module 'alt-client' {
    interface ICustomEmitEvent {
        anyResourceStop: (impossible: number) => void
        test: (possible: string) => void
    }
}

alt.on("anyResourceStop", (name) => {}) // name: string, valid
alt.on("anyResourceStop", (impossible: number) => {}) // now this is invalid
alt.on("anyResourceStop", (impossibleToo: boolean) => {}) // invalid

alt.once("anyResourceStop", (player) => {}) // name: string, valid
alt.once("anyResourceStop", (impossible: number) => {}) // now this is invalid
alt.once("anyResourceStop", (impossibleToo: boolean) => {}) // invalid

alt.off("anyResourceStop", (player) => {}) // name: string, valid
alt.off("anyResourceStop", (impossible: number) => {}) // now this is invalid
alt.off("anyResourceStop", (impossibleToo: boolean) => {}) // invalid

alt.on("test", (adawdawdw: number) => {}) // invalid
alt.once("test", (adawdawdw: number) => {}) // invalid
alt.off("test", (adawdawdw: number) => {}) // invalid


alt.on("awdawd", (adawdawdw: number) => {}) // valid
alt.once("awdawd", (adawdawdw: number) => {}) // valid
alt.off("awdawd", (adawdawdw: number) => {}) // valid
```
