### PR TITLE
client|shared|server: Git rid of ugly Array types

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -423,7 +423,7 @@ declare module "alt-client" {
     /**
      * Child node ids.
      */
-    readonly children?: ReadonlyArray<number>;
+    readonly children?: readonly number[];
 
     /**
      * The reason of being not optimized. The function may be deoptimized or marked as don't optimize.
@@ -433,7 +433,7 @@ declare module "alt-client" {
     /**
      * An array of source position ticks.
      */
-    readonly positionTicks: ReadonlyArray<IProfileTickInfo>;
+    readonly positionTicks: readonly IProfileTickInfo[];
   }
 
   export interface IProfileTickInfo {
@@ -607,7 +607,7 @@ declare module "alt-client" {
     public constructor(maxEntitiesInStream: number);
 
     /** Returns all Virtual Entity Group instances */
-    public static readonly all: ReadonlyArray<VirtualEntityGroup>;
+    public static readonly all: readonly VirtualEntityGroup[];
 
     /** Maximum streaming range of the Virtual Entity Group */
     public readonly maxEntitiesInStream: number;
@@ -619,9 +619,9 @@ declare module "alt-client" {
     public constructor(group: VirtualEntityGroup, position: shared.Vector3, streamingDistance: number, data?: Record<string, any>);
 
     /** Returns all Virtual Entity instances */
-    public static readonly all: ReadonlyArray<VirtualEntity>;
+    public static readonly all: readonly VirtualEntity[];
 
-    public static readonly streamedIn: ReadonlyArray<VirtualEntity>;
+    public static readonly streamedIn: readonly VirtualEntity[];
 
     /** Virtual Entity Group this entity belongs to */
     public readonly group: VirtualEntityGroup;
@@ -656,7 +656,7 @@ declare module "alt-client" {
      * Returns all set meta keys of the Virtual Entity.
      * Only available for server-side created Virtual Entities.
      */
-    public getStreamSyncedMetaKeys(): ReadonlyArray<string>;
+    public getStreamSyncedMetaKeys(): readonly string[];
   }
 
   /** @beta */
@@ -669,7 +669,7 @@ declare module "alt-client" {
      */
     public constructor(source: string, volume?: number, radio?: boolean);
 
-    public static readonly all: ReadonlyArray<Audio>;
+    public static readonly all: readonly Audio[];
 
     public static readonly count: number;
 
@@ -706,7 +706,7 @@ declare module "alt-client" {
     /**
      * @remarks This method has no effect if the {@link frontendPlay} property returns true.
      */
-    public getOutputs(): ReadonlyArray<AudioOutput | number>;
+    public getOutputs(): readonly (AudioOutput | number)[];
 
     public play(): void;
     public pause(): void;
@@ -744,7 +744,7 @@ declare module "alt-client" {
   export class AudioOutput extends BaseObject {
     protected constructor();
 
-    public static readonly all: ReadonlyArray<AudioOutput>;
+    public static readonly all: readonly AudioOutput[];
 
     public static readonly count: number;
 
@@ -819,7 +819,7 @@ declare module "alt-client" {
     public readonly streamingDistance: number;
 
     /** @beta */
-    public static readonly all: ReadonlyArray<Checkpoint>;
+    public static readonly all: readonly Checkpoint[];
 
     /** @beta */
     public static readonly count: number;
@@ -883,7 +883,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Entity>;
+    public static readonly all: readonly Entity[];
 
     /** Internal game id that can be used in native calls */
     public readonly scriptID: number;
@@ -967,7 +967,7 @@ declare module "alt-client" {
     public hasSyncedMeta(key: string): boolean;
     public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): boolean;
 
-    public getSyncedMetaKeys(): ReadonlyArray<string>;
+    public getSyncedMetaKeys(): readonly string[];
 
     /**
      * Gets a value using the specified key.
@@ -989,7 +989,7 @@ declare module "alt-client" {
     public hasStreamSyncedMeta(key: string): boolean;
     public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): boolean;
 
-    public getStreamSyncedMetaKeys(): ReadonlyArray<string>;
+    public getStreamSyncedMetaKeys(): readonly string[];
 
     public frozen: boolean;
   }
@@ -1009,7 +1009,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Player>;
+    public static readonly all: readonly Player[];
 
     /** @beta */
     public static readonly count: number;
@@ -1017,7 +1017,7 @@ declare module "alt-client" {
     /**
      * Array with all streamed in players.
      */
-    public static readonly streamedIn: ReadonlyArray<Player>;
+    public static readonly streamedIn: readonly Player[];
 
     /**
      * The local player instance.
@@ -1041,7 +1041,7 @@ declare module "alt-client" {
     /**
      * Current weapon components.
      */
-    public readonly currentWeaponComponents: ReadonlyArray<number>;
+    public readonly currentWeaponComponents: readonly number[];
 
     /** @beta */
     public hasWeaponComponent(weaponModel: string | number, component: string | number): boolean;
@@ -1298,7 +1298,7 @@ declare module "alt-client" {
      */
     public readonly currentAmmo: number;
 
-    public readonly weapons: ReadonlyArray<shared.IWeapon>;
+    public readonly weapons: readonly shared.IWeapon[];
 
     public readonly currentWeaponData: WeaponData | null;
 
@@ -1306,9 +1306,9 @@ declare module "alt-client" {
 
     public getWeaponAmmo(weaponName: string): number;
 
-    public getWeaponComponents(hash: number): ReadonlyArray<number>;
+    public getWeaponComponents(hash: number): readonly number[];
 
-    public getWeaponComponents(weaponName: string): ReadonlyArray<number>;
+    public getWeaponComponents(weaponName: string): readonly number[];
 
     public hasWeapon(hash: number): boolean;
 
@@ -1350,7 +1350,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Vehicle>;
+    public static readonly all: readonly Vehicle[];
 
     /** @beta */
     public static readonly count: number;
@@ -1358,7 +1358,7 @@ declare module "alt-client" {
     /**
      * Array with all streamed in vehicles.
      */
-    public static readonly streamedIn: ReadonlyArray<Vehicle>;
+    public static readonly streamedIn: readonly Vehicle[];
 
     /**
      * Vehicle gear.
@@ -1928,7 +1928,7 @@ declare module "alt-client" {
     public url: string;
 
     /** @beta */
-    public static readonly all: ReadonlyArray<WebView>;
+    public static readonly all: readonly WebView[];
 
     /** @beta */
     public static readonly count: number;
@@ -2113,7 +2113,7 @@ declare module "alt-client" {
     public removeOutput(output: AudioOutput): void;
 
     /** @beta */
-    public getOutputs(): ReadonlyArray<AudioOutput | number>;
+    public getOutputs(): readonly (AudioOutput | number)[];
 
     /** @beta */
     public reload(ignoreCache?: boolean): void;
@@ -2264,7 +2264,7 @@ declare module "alt-client" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Blip>;
+    public static readonly all: readonly Blip[];
 
     /** @beta */
     public static readonly count: number;
@@ -2658,7 +2658,7 @@ declare module "alt-client" {
      *
      * @remarks This function requires [Extended Voice API](https://docs.altv.mp/articles/permissions.html) permission from the user.
      * */
-    public static getAvailableInputDevices(): ReadonlyArray<IInputDevice>;
+    public static getAvailableInputDevices(): readonly IInputDevice[];
 
     /**
      * Determines if the voice activation is enabled.
@@ -3073,7 +3073,7 @@ declare module "alt-client" {
    * @param weathers An array containing the weather ids for the weather cycle.
    * @param multipliers An array containing the multipliers for the weather cycle.
    */
-  export function setWeatherCycle(weathers: Array<number>, multipliers: Array<number>): void;
+  export function setWeatherCycle(weathers: number[], multipliers: number[]): void;
 
   /**
    * Sets whether the weather sync is active.
@@ -3522,7 +3522,7 @@ declare module "alt-client" {
 
     public readonly ownerDocument: RmlDocument;
 
-    public readonly childNodes: ReadonlyArray<RmlElement>;
+    public readonly childNodes: readonly RmlElement[];
 
     public appendChild(child: RmlElement): void;
 
@@ -3538,7 +3538,7 @@ declare module "alt-client" {
 
     public hasClass(name: string): boolean;
 
-    public getClassList(): ReadonlyArray<string>;
+    public getClassList(): readonly string[];
 
     public addPseudoClass(name: string): boolean;
 
@@ -3546,7 +3546,7 @@ declare module "alt-client" {
 
     public hasPseudoClass(name: string): boolean;
 
-    public getPseudoClassList(): ReadonlyArray<string>;
+    public getPseudoClassList(): readonly string[];
 
     public setOffset(element: RmlElement, offset: shared.IVector2, fixed?: boolean): void;
 
@@ -3580,13 +3580,13 @@ declare module "alt-client" {
 
     public getElementByID(id: string): RmlElement | null;
 
-    public getElementsByTagName(tag: string): ReadonlyArray<RmlElement>;
+    public getElementsByTagName(tag: string): readonly RmlElement[];
 
-    public getElementsByClassName(className: string): ReadonlyArray<RmlElement>;
+    public getElementsByClassName(className: string): readonly RmlElement[];
 
     public querySelector(selector: string): RmlElement | null;
 
-    public querySelectorAll(selector: string): ReadonlyArray<RmlElement>;
+    public querySelectorAll(selector: string): readonly RmlElement[];
 
     public focus(): boolean;
 
@@ -3720,7 +3720,7 @@ declare module "alt-client" {
        * ```
        *
        */
-      constructor(keyCode: shared.KeyCode | Array<shared.KeyCode>, callback: () => void, eventType?: "keyup" | "keydown");
+      constructor(keyCode: shared.KeyCode | shared.KeyCode[], callback: () => void, eventType?: "keyup" | "keydown");
       public destroy(): void;
     }
 
@@ -3886,9 +3886,9 @@ declare module "alt-client" {
      */
     constructor(model: string | number, pos: shared.Vector3, rot: shared.Vector3, noOffset?: boolean, dynamic?: boolean, useStreaming?: boolean, streamingDistance?: number);
 
-    public static readonly all: ReadonlyArray<LocalObject>;
+    public static readonly all: readonly LocalObject[];
 
-    public static readonly allWorld: ReadonlyArray<LocalObject>;
+    public static readonly allWorld: readonly LocalObject[];
 
     /**
      * Retrieves the ped from the pool.
@@ -3977,7 +3977,7 @@ declare module "alt-client" {
   export class WeaponObject extends LocalObject {
     constructor(weaponHash: string | number, pos: shared.Vector3, rot: shared.Vector3, modelHash?: string | number, numAmmo?: number, createDefaultComponents?: boolean, scale?: number, useStreaming?: boolean, streamingDistance?: number);
 
-    public static readonly all: ReadonlyArray<WeaponObject>;
+    public static readonly all: readonly WeaponObject[];
 
     public static readonly count: number;
 
@@ -3996,7 +3996,7 @@ declare module "alt-client" {
 
   /** @beta */
   export class Object extends Entity {
-    public static readonly all: ReadonlyArray<Object>;
+    public static readonly all: readonly Object[];
 
     public static readonly count: number;
 
@@ -4026,9 +4026,9 @@ declare module "alt-client" {
      */
     public static getByScriptID(scriptID: number): Ped | null;
 
-    public static readonly all: ReadonlyArray<Ped>;
+    public static readonly all: readonly Ped[];
 
-    public static readonly streamedIn: ReadonlyArray<Ped>;
+    public static readonly streamedIn: readonly Ped[];
 
     public static readonly count: number;
 
@@ -4148,7 +4148,7 @@ declare module "alt-client" {
      */
     public static getByID(id: number): Marker | null;
 
-    public static readonly all: ReadonlyArray<Marker>;
+    public static readonly all: readonly Marker[];
 
     public visible: boolean;
 
@@ -4179,7 +4179,7 @@ declare module "alt-client" {
 
   /** @beta */
   export class Colshape extends WorldObject {
-    public static readonly all: ReadonlyArray<Colshape>;
+    public static readonly all: readonly Colshape[];
 
     public readonly colshapeType: shared.ColShapeType;
 
@@ -4194,7 +4194,7 @@ declare module "alt-client" {
     public readonly max: shared.Vector2 | shared.Vector3;
     public readonly minZ: number;
     public readonly maxZ: number;
-    public readonly points: Vector2[];
+    public readonly points: shared.Vector2[];
 
     /**
      * Retrieves the colshape from the pool.
@@ -4253,7 +4253,7 @@ declare module "alt-client" {
 
   /** @beta */
   export class ColshapePolygon extends Colshape {
-    constructor(minZ: number, maxZ: number, points: Array<shared.IVector2>);
+    constructor(minZ: number, maxZ: number, points: shared.IVector2[]);
   }
 
   /** @beta */
@@ -4268,7 +4268,7 @@ declare module "alt-client" {
      */
     public static getByID(id: number): TextLabel | null;
 
-    //public static readonly all: ReadonlyArray<TextLabel>;
+    //public static readonly all: readonly TextLabel[];
 
     public visible: boolean;
 

--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -354,7 +354,7 @@ declare module "alt-client" {
     /**
      * The list of profile nodes. First item is the root node.
      */
-    readonly nodes: IProfileNode[];
+    readonly nodes: readonly IProfileNode[];
 
     /**
      * Profiling start timestamp in microseconds.
@@ -369,12 +369,12 @@ declare module "alt-client" {
     /**
      * Ids of samples top nodes.
      */
-    readonly samples: number[];
+    readonly samples: readonly number[];
 
     /**
      * Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime.
      */
-    readonly timeDeltas: number[];
+    readonly timeDeltas: readonly number[];
   }
 
   export interface IProfileCallFrame {
@@ -2089,7 +2089,7 @@ declare module "alt-client" {
      * @param eventName Name of the event.
      * @returns Array of listener functions for that event.
      */
-    public getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
+    public getEventListeners(eventName: string | null): readonly ((...args: any[]) => void)[];
 
     /**
      * Sets the specified header to the specified value.
@@ -3175,7 +3175,7 @@ declare module "alt-client" {
     /**
      * Gets all added sub protocols.
      */
-    public getSubProtocols(): string[];
+    public getSubProtocols(): readonly string[];
 
     /**
      * Sets the specified header to the specified value.
@@ -3191,7 +3191,7 @@ declare module "alt-client" {
      * @param eventName Name of the event.
      * @returns Array of listener functions for that event.
      */
-    public getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
+    public getEventListeners(eventName: string | null): readonly ((...args: any[]) => void)[];
   }
 
   /**
@@ -3234,7 +3234,7 @@ declare module "alt-client" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getRemoteEventListeners(eventName: string | null): ((...args: any[]) => void)[];
+  export function getRemoteEventListeners(eventName: string | null): readonly ((...args: any[]) => void)[];
 
   export class HttpClient extends BaseObject {
     public constructor();
@@ -3454,7 +3454,7 @@ declare module "alt-client" {
 
     public off(eventName: string, func: (...args: any[]) => void): void;
 
-    public getEventListeners(eventName: string): ((senderElement: RmlElement, ...args: any[]) => void)[];
+    public getEventListeners(eventName: string): readonly ((senderElement: RmlElement, ...args: any[]) => void)[];
 
     public readonly relativeOffset: shared.Vector2;
 
@@ -3858,7 +3858,7 @@ declare module "alt-client" {
     public static getForHash(weaponHash: number): WeaponData;
 
     /** @beta */
-    public static allHashes: WeaponData[];
+    public static allHashes: readonly WeaponData[];
   }
 
   export function loadDefaultIpls(): void;
@@ -4194,7 +4194,7 @@ declare module "alt-client" {
     public readonly max: shared.Vector2 | shared.Vector3;
     public readonly minZ: number;
     public readonly maxZ: number;
-    public readonly points: shared.Vector2[];
+    public readonly points: readonly shared.Vector2[];
 
     /**
      * Retrieves the colshape from the pool.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1438,7 +1438,7 @@ declare module "alt-server" {
     public clearDecorations(): void;
 
     /** @beta */
-    public getDecorations(): IDecoration[];
+    public getDecorations(): readonly IDecoration[];
 
     /** @beta */
     public playAnimation(animDict: string, animName: string, blendInSpeed?: number, blendOutSpeed?: number, duration?: number, flags?: number, playbackRate?: number, lockX?: boolean, lockY?: boolean, lockZ?: boolean): void;
@@ -2751,7 +2751,7 @@ declare module "alt-server" {
     /** @beta */
     public readonly maxZ: number;
     /** @beta */
-    public readonly points: shared.Vector2[];
+    public readonly points: readonly shared.Vector2[];
 
     /**
      * Retrieves the colshape from the pool.
@@ -3207,7 +3207,7 @@ declare module "alt-server" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getRemoteEventListeners(eventName: string | null): ((...args: any[]) => void)[];
+  export function getRemoteEventListeners(eventName: string | null): readonly ((...args: any[]) => void)[];
 
   export function getVehicleModelInfoByHash(vehicleHash: number): IVehicleModel;
 
@@ -3224,13 +3224,13 @@ declare module "alt-server" {
   export function toggleWorldProfiler(state: boolean): void;
 
   /** @beta */
-  export function getEntitiesInDimension(dimension: number, allowedTypes: shared.BaseObjectType): Entity[];
+  export function getEntitiesInDimension(dimension: number, allowedTypes: shared.BaseObjectType): readonly Entity[];
 
   /** @beta */
-  export function getEntitiesInRange(position: shared.IVector3, range: number, dimension: number, allowedTypes: shared.BaseObjectType): Entity[];
+  export function getEntitiesInRange(position: shared.IVector3, range: number, dimension: number, allowedTypes: shared.BaseObjectType): readonly Entity[];
 
   /** @beta */
-  export function getClosestEntities(position: shared.IVector3, range: number, dimension: number, limit: number, allowedTypes: shared.BaseObjectType): Entity[];
+  export function getClosestEntities(position: shared.IVector3, range: number, dimension: number, limit: number, allowedTypes: shared.BaseObjectType): readonly Entity[];
 
   /** @beta */
   export function setVoiceExternalPublic(host: string, port: number): void;

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -248,7 +248,7 @@ declare module "alt-server" {
 
   export class ConnectionInfo {
     /** @beta */
-    static readonly all: ReadonlyArray<IConnectionInfo>;
+    static readonly all: readonly IConnectionInfo[];
     /** @beta */
     static getByID(id: number): IConnectionInfo | null;
   }
@@ -303,7 +303,7 @@ declare module "alt-server" {
     vehicleDestroy: (vehicle: Vehicle) => void;
     vehicleDetach: (vehicle: Vehicle, detachedVehicle: Vehicle) => void;
     weaponDamage: (source: Player, target: Entity, weaponHash: number, damage: number, offset: shared.Vector3, bodyPart: shared.BodyPart) => number | boolean | void;
-    startFire: (player: Player, fires: Array<IFireInfo>) => boolean | void;
+    startFire: (player: Player, fires: IFireInfo[]) => boolean | void;
     startProjectile: (player: Player, pos: shared.Vector3, dir: shared.Vector3, ammoHash: number, weaponHash: number) => boolean | void;
     playerWeaponChange: (player: Player, oldWeapon: number, weapon: number) => void;
     vehicleDamage: (vehicle: Vehicle, attacker: Entity | null, bodyHealthDamage: number, additionalBodyHealthDamage: number, engineHealthDamage: number, petrolTankDamage: number, weapon: number) => void;
@@ -450,10 +450,10 @@ declare module "alt-server" {
     readonly interiorColor: number;
     readonly dashboardColor: number;
     readonly hasAutoAttachTrailer: boolean;
-    readonly availableModkits: ReadonlyArray<boolean>;
+    readonly availableModkits: readonly boolean[];
     hasExtra(extraId: number): boolean;
     hasDefaultExtra(extraId: number): boolean;
-    readonly bones: ReadonlyArray<IBoneInfo>;
+    readonly bones: readonly IBoneInfo[];
     /** @beta */
     readonly canAttachCars: boolean;
   }
@@ -465,7 +465,7 @@ declare module "alt-server" {
     readonly dlcName: string;
     readonly defaultUnarmedWeapon: string;
     readonly movementClipSet: string;
-    readonly bones: ReadonlyArray<IBoneInfo>;
+    readonly bones: readonly IBoneInfo[];
   }
 
   /** @beta */
@@ -586,8 +586,8 @@ declare module "alt-server" {
    * Documentation: https://docs.altv.mp/articles/configs/server.html
    */
   export interface IServerConfig {
-    readonly resources: ReadonlyArray<string>;
-    readonly modules: ReadonlyArray<string>;
+    readonly resources: readonly string[];
+    readonly modules: readonly string[];
     readonly name?: string;
     readonly host?: string;
     readonly port?: number;
@@ -606,7 +606,7 @@ declare module "alt-server" {
     readonly announceRetryErrorDelay?: number;
     readonly announceRetryErrorAttempts?: number;
     readonly duplicatePlayers?: number;
-    readonly tags?: ReadonlyArray<string>;
+    readonly tags?: readonly string[];
     readonly useEarlyAuth?: boolean;
     readonly earlyAuthUrl?: string;
     readonly useCdn?: boolean;
@@ -618,7 +618,7 @@ declare module "alt-server" {
     readonly mapBoundsMaxY?: number;
     readonly mapCellAreaSize?: number;
     readonly colShapeTickRate?: number;
-    readonly logStream?: ReadonlyArray<string>;
+    readonly logStream?: readonly string[];
     readonly entityWorkerCount?: number;
     readonly connectionQueue?: boolean;
 
@@ -647,7 +647,7 @@ declare module "alt-server" {
       readonly "global-fetch"?: boolean;
       readonly "global-webcrypto"?: boolean;
       readonly "network-imports"?: boolean;
-      readonly "extra-cli-args"?: ReadonlyArray<string>;
+      readonly "extra-cli-args"?: readonly string[];
     };
 
     readonly "csharp-module"?: {
@@ -727,7 +727,7 @@ declare module "alt-server" {
     public constructor(maxEntitiesInStream: number);
 
     /** Returns all Virtual Entity Group instances */
-    public static readonly all: ReadonlyArray<VirtualEntityGroup>;
+    public static readonly all: readonly VirtualEntityGroup[];
 
     /** Maximum streaming range inside the Virtual Entity Group */
     public readonly maxEntitiesInStream: number;
@@ -739,7 +739,7 @@ declare module "alt-server" {
     public constructor(group: VirtualEntityGroup, position: shared.Vector3, streamingDistance: number, data?: Record<string, any>);
 
     /** Returns all Virtual Entity instances */
-    public static readonly all: ReadonlyArray<VirtualEntity>;
+    public static readonly all: readonly VirtualEntity[];
 
     /** Virtual Entity Group this entity belongs to */
     public readonly group: VirtualEntityGroup;
@@ -769,7 +769,7 @@ declare module "alt-server" {
     public hasStreamSyncedMeta(key: string): boolean;
     public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomVirtualEntityStreamSyncedMeta>>(key: K): boolean;
 
-    public getStreamSyncedMetaKeys(): ReadonlyArray<string>;
+    public getStreamSyncedMetaKeys(): readonly string[];
 
     /**
      * Stores the given value with the specified key.
@@ -808,7 +808,7 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Entity>;
+    public static readonly all: readonly Entity[];
 
     /**
      * Network owner of the entity.
@@ -888,7 +888,7 @@ declare module "alt-server" {
     public hasSyncedMeta(key: string): boolean;
     public hasSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntitySyncedMeta>>(key: K): boolean;
 
-    public getSyncedMetaKeys(): ReadonlyArray<string>;
+    public getSyncedMetaKeys(): readonly string[];
 
     /**
      * Stores the given value with the specified key.
@@ -931,7 +931,7 @@ declare module "alt-server" {
     public hasStreamSyncedMeta(key: string): boolean;
     public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomEntityStreamSyncedMeta>>(key: K): boolean;
 
-    public getStreamSyncedMetaKeys(): ReadonlyArray<string>;
+    public getStreamSyncedMetaKeys(): readonly string[];
 
     /**
      * Stores the given value with the specified key.
@@ -1014,15 +1014,15 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Player>;
+    public static readonly all: readonly Player[];
     /** @beta */
-    public readonly streamedEntities: ReadonlyArray<{ entity: Entity; distance: number }>;
+    public readonly streamedEntities: readonly { entity: Entity; distance: number }[];
     /** @beta */
     public static readonly count: number;
     public armour: number;
     public currentWeapon: number;
-    public readonly weapons: ReadonlyArray<shared.IWeapon>;
-    public readonly currentWeaponComponents: ReadonlyArray<number>;
+    public readonly weapons: readonly shared.IWeapon[];
+    public readonly currentWeaponComponents: readonly number[];
     public readonly currentWeaponTintIndex: number;
     public readonly entityAimOffset: shared.Vector3;
     public readonly entityAimingAt: Entity | null;
@@ -1527,7 +1527,7 @@ declare module "alt-server" {
     public hasLocalMeta(key: string): boolean;
     public hasLocalMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerLocalMeta>>(key: K): boolean;
 
-    public getLocalMetaKeys(): ReadonlyArray<string>;
+    public getLocalMetaKeys(): readonly string[];
 
     // normal meta
 
@@ -1618,7 +1618,7 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Vehicle>;
+    public static readonly all: readonly Vehicle[];
 
     /** @beta */
     public static readonly count: number;
@@ -2586,7 +2586,7 @@ declare module "alt-server" {
      * }
      * ```
      */
-    public static readonly all: ReadonlyArray<Blip>;
+    public static readonly all: readonly Blip[];
 
     /** @beta */
     public static readonly count: number;
@@ -2686,7 +2686,7 @@ declare module "alt-server" {
     public isGlobal: boolean;
 
     /** @beta */
-    public readonly targets: ReadonlyArray<Player>;
+    public readonly targets: readonly Player[];
 
     /** @beta */
     public addTarget(player: Player): void;
@@ -2729,7 +2729,7 @@ declare module "alt-server" {
 
   export class Colshape extends WorldObject {
     /** @beta */
-    public static readonly all: ReadonlyArray<Colshape>;
+    public static readonly all: readonly Colshape[];
 
     public readonly colshapeType: shared.ColShapeType;
 
@@ -2806,7 +2806,7 @@ declare module "alt-server" {
   }
 
   export class ColshapePolygon extends Colshape {
-    constructor(minZ: number, maxZ: number, points: Array<shared.IVector2>);
+    constructor(minZ: number, maxZ: number, points: shared.IVector2[]);
   }
 
   export class Checkpoint extends Colshape {
@@ -2821,7 +2821,7 @@ declare module "alt-server" {
     public readonly streamingDistance: number;
 
     /** @beta */
-    public static readonly all: ReadonlyArray<Checkpoint>;
+    public static readonly all: readonly Checkpoint[];
 
     /** @beta */
     public static readonly count: number;
@@ -2872,7 +2872,7 @@ declare module "alt-server" {
     public hasStreamSyncedMeta<K extends shared.ExtractStringKeys<shared.ICustomPlayerStreamSyncedMeta>>(key: K): boolean;
 
     /** @beta */
-    public getStreamSyncedMetaKeys(): ReadonlyArray<string>;
+    public getStreamSyncedMetaKeys(): readonly string[];
   }
 
   export class VoiceChannel extends BaseObject {
@@ -2926,7 +2926,7 @@ declare module "alt-server" {
     /** @deprecated See {@link ICustomVoiceChannelMeta} */
     public setMeta<V extends any, K extends string = string>(key: K, value: shared.InterfaceValueByKey<ICustomVoiceChannelMeta, K, V>): void;
 
-    public readonly players: ReadonlyArray<Player>;
+    public readonly players: readonly Player[];
 
     public readonly playerCount: number;
   }
@@ -2935,7 +2935,7 @@ declare module "alt-server" {
     public readonly path: string;
 
     public static getByName(name: string): Resource | null;
-    public static readonly all: ReadonlyArray<Resource>;
+    public static readonly all: readonly Resource[];
     public static readonly current: Resource;
   }
 
@@ -3322,7 +3322,7 @@ declare module "alt-server" {
      */
     public static getByID(id: number): Ped | null;
 
-    public static readonly all: ReadonlyArray<Ped>;
+    public static readonly all: readonly Ped[];
     public static readonly count: number;
     public currentWeapon: number;
     public health: number;
@@ -3334,7 +3334,7 @@ declare module "alt-server" {
   export class Object extends Entity {
     constructor(model: string | number, position: shared.IVector3, rotation: shared.IVector3, alpha?: number, textureVariation?: number, lodDistance?: number);
 
-    public static readonly all: ReadonlyArray<Object>;
+    public static readonly all: readonly Object[];
 
     public static readonly count: number;
 
@@ -3364,7 +3364,7 @@ declare module "alt-server" {
      */
     public static getByID(id: number): Marker | null;
 
-    public static readonly all: ReadonlyArray<Marker>;
+    public static readonly all: readonly Marker[];
 
     public visible: boolean;
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1678,13 +1678,13 @@ declare module "alt-shared" {
    */
   export interface IResourceConfig {
     readonly type?: string;
-    readonly deps?: ReadonlyArray<string>;
+    readonly deps?: readonly string[];
     readonly main?: string;
     readonly "client-main"?: string;
     readonly "client-type"?: string;
-    readonly "client-files"?: ReadonlyArray<string>;
-    readonly "required-permissions"?: ReadonlyArray<Permission>;
-    readonly "optional-permissions"?: ReadonlyArray<Permission>;
+    readonly "client-files"?: readonly string[];
+    readonly "required-permissions"?: readonly Permission[];
+    readonly "optional-permissions"?: readonly Permission[];
 
     readonly [key: string]: unknown;
   }
@@ -1775,7 +1775,7 @@ declare module "alt-shared" {
   export interface IWeapon {
     readonly hash: number;
     readonly tintIndex: number;
-    readonly components: ReadonlyArray<number>;
+    readonly components: readonly number[];
   }
 
   export const enum VehicleLockState {
@@ -2563,7 +2563,7 @@ declare module "alt-shared" {
     public hasMeta(key: string): boolean;
     public hasMeta<K extends ExtractStringKeys<ICustomBaseObjectMeta>>(key: K): boolean;
 
-    public getMetaDataKeys(): ReadonlyArray<string>;
+    public getMetaDataKeys(): readonly string[];
 
     /**
      * Stores the given value with the specified key.
@@ -2598,7 +2598,7 @@ declare module "alt-shared" {
     public hasSyncedMeta(key: string): boolean;
     public hasSyncedMeta<K extends ExtractStringKeys<ICustomBaseObjectSyncedMeta>>(key: K): boolean;
 
-    public getSyncedMetaKeys(): ReadonlyArray<string>;
+    public getSyncedMetaKeys(): readonly string[];
 
     /**
      * Returns the ref count of the entity.
@@ -2674,7 +2674,7 @@ declare module "alt-shared" {
    * Returns all meta keys which have been set
    * @beta
    */
-  export function getMetaKeys(): ReadonlyArray<string>;
+  export function getMetaKeys(): readonly string[];
 
   /**
    * Determines whether contains the specified key.
@@ -2713,7 +2713,7 @@ declare module "alt-shared" {
    * Returns all synced meta keys which have been set
    * @beta
    */
-  export function getSyncedMetaKeys(): ReadonlyArray<string>;
+  export function getSyncedMetaKeys(): readonly string[];
 
   /**
    * Determines whether contains the specified key.
@@ -2914,7 +2914,7 @@ declare module "alt-shared" {
    */
   export const isServer: boolean;
 
-  export function getAllResources(): ReadonlyArray<IResource>;
+  export function getAllResources(): readonly IResource[];
 
   export function time(timerName: string): void;
 
@@ -2932,15 +2932,15 @@ declare module "alt-shared" {
     public readonly name: string;
     public readonly main: string;
     public readonly exports: Record<string, any>;
-    public readonly dependencies: ReadonlyArray<string>;
-    public readonly dependants: ReadonlyArray<string>;
-    public readonly requiredPermissions: ReadonlyArray<Permission>;
-    public readonly optionalPermissions: ReadonlyArray<Permission>;
+    public readonly dependencies: readonly string[];
+    public readonly dependants: readonly string[];
+    public readonly requiredPermissions: readonly Permission[];
+    public readonly optionalPermissions: readonly Permission[];
     public readonly valid: boolean;
 
     public readonly config: IResourceConfig;
     public static getByName(name: string): Resource | null;
-    public static readonly all: ReadonlyArray<Resource>;
+    public static readonly all: readonly Resource[];
     public static readonly current: Resource;
   }
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -3007,7 +3007,7 @@ declare module "alt-shared" {
    * @param eventName Name of the event or null for generic event.
    * @returns Array of listener functions for that event.
    */
-  export function getEventListeners(eventName: string | null): ((...args: any[]) => void)[];
+  export function getEventListeners(eventName: string | null): readonly ((...args: any[]) => void)[];
 
   export function stringToSHA256(string: string): string;
 


### PR DESCRIPTION
Replaced all `ReadonlyArray<T>` and `Array<T>` with `readonly T[]` and `T[]`. Added missing `readonly` to arrays returned from API