### PR TITLE
server: Add Ped.maxHealth

### DIFF
--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -3502,6 +3502,7 @@ declare module "alt-server" {
     public static readonly count: number;
     public currentWeapon: number;
     public health: number;
+    public maxHealth: number;
     public armour: number;
   }
 


### PR DESCRIPTION
Property maxHealth is missing from Ped class. It exists in js-module:

https://github.com/altmp/altv-js-module/blob/a6bb1914cc55865909fc09fc25c536be66883d3d/server/src/bindings/Ped.cpp#L78