### PR TITLE
Client|Shared|Server: Consisting typing for RPC

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -2779,7 +2779,8 @@ declare module "alt-client" {
    *
    * @beta
    */
-  export function emitRpc(rpcName: string, ...args: unknown[]): Promise<unknown>;
+  export function emitRpc<K extends keyof shared.ICustomClientServerRpc>(rpcName: K, ...args: Parameters<shared.ICustomClientServerRpc[K]>): Promise<ReturnType<shared.ICustomClientServerRpc[K]>>;
+  export function emitRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomClientServerRpc>, ...args: any[]): Promise<any>;
 
   /**
    * Subscribes to a client event with the specified listener.
@@ -2790,7 +2791,8 @@ declare module "alt-client" {
    *
    * @beta
    */
-  export function onRpc(rpcName: string, listener: (player: Player, ...args: unknown[]) => Promise<unknown> | unknown): void;
+  export function onRpc<K extends keyof shared.ICustomServerClientRpc>(rpcName: K, listener: (...args: Parameters<shared.ICustomServerClientRpc[K]>) => Promise<any> | ReturnType<any>): void;
+  export function onRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomServerClientRpc>, listener: (...args: any[]) => Promise<any> | any): void;
 
   /**
    *
@@ -2799,7 +2801,8 @@ declare module "alt-client" {
    *
    * @beta
    */
-  export function offRpc(rpcName: string, listener?: (player: Player, ...args: unknown[]) => Promise<unknown> | unknown): void;
+  export function offRpc<K extends keyof shared.ICustomServerClientRpc>(rpcName: K, listener?: (...args: Parameters<shared.ICustomServerClientRpc[K]>) => Promise<ReturnType<shared.ICustomServerClientRpc[K]>> | ReturnType<shared.ICustomServerClientRpc[K]>): void;
+  export function offRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomServerClientRpc>, listener?: (...args: any[]) => Promise<any> | any): void;
 
   /**
    * Returns whether the game controls are currently enabled.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1181,7 +1181,8 @@ declare module "alt-server" {
      *
      * @beta
      */
-    public emitRpc(rpcName: string, ...args: unknown[]): Promise<unknown>;
+    public emitRpc<K extends keyof shared.ICustomServerClientRpc>(rpcName: K, ...args: Parameters<shared.ICustomServerClientRpc[K]>): Promise<ReturnType<shared.ICustomServerClientRpc[K]>>;
+    public emitRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomServerClientRpc>, ...args: any[]): Promise<any>;
 
     public addWeaponComponent(weaponHash: number, component: number): void;
 
@@ -3145,7 +3146,8 @@ declare module "alt-server" {
    *
    * @beta
    */
-  export function onRpc(rpcName: string, listener: (player: Player, ...args: unknown[]) => Promise<unknown> | unknown): void;
+  export function onRpc<K extends keyof shared.ICustomClientServerRpc>(rpcName: K, listener: (player: Player, ...args: Parameters<shared.ICustomClientServerRpc[K]>) => Promise<ReturnType<shared.ICustomClientServerRpc[K]>> | ReturnType<shared.ICustomClientServerRpc[K]>): void;
+  export function onRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomClientServerRpc>, listener: (player: Player, ...args: any[]) => Promise<any> | any): void;
 
   /**
    *
@@ -3153,8 +3155,9 @@ declare module "alt-server" {
    * @param listener Listener that should be added.
    *
    * @beta
-   */
-  export function offRpc(rpcName: string, listener?: (player: Player, ...args: unknown[]) => Promise<unknown> | unknown): void;
+  */
+  export function offRpc<K extends keyof shared.ICustomClientServerRpc>(rpcName: string, listener: (player: Player, ...args: Parameters<shared.ICustomClientServerRpc[K]>) => Promise<ReturnType<shared.ICustomClientServerRpc[K]>> | ReturnType<shared.ICustomClientServerRpc[K]>): void;
+  export function offRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomClientServerRpc>, listener?: (player: Player, ...args: any[]) => Promise<any> | any): void;
 
   /**
    * Change the server password at runtime.

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -3155,7 +3155,7 @@ declare module "alt-server" {
    * @param listener Listener that should be added.
    *
    * @beta
-  */
+   */
   export function offRpc<K extends keyof shared.ICustomClientServerRpc>(rpcName: string, listener: (player: Player, ...args: Parameters<shared.ICustomClientServerRpc[K]>) => Promise<ReturnType<shared.ICustomClientServerRpc[K]>> | ReturnType<shared.ICustomClientServerRpc[K]>): void;
   export function offRpc<K extends string>(rpcName: Exclude<K, keyof shared.ICustomClientServerRpc>, listener?: (player: Player, ...args: any[]) => Promise<any> | any): void;
 

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1933,6 +1933,40 @@ declare module "alt-shared" {
    */
   export interface ICustomClientServerEvent {}
 
+  /**
+   * Extend `player.emitRpc` and `alt.onRpc` auto-completion by merging interfaces.
+   *
+   * @example
+   * ```ts
+   * declare module 'alt-client' {
+   *    interface ICustomServerClientRpc {
+   *        myRpc: (arg1: string, arg2: { key: string, value: number }): Promise<boolean>
+   *    }
+   * }
+   * ```
+   *
+   * @export
+   * @interface ICustomServerClientRpc
+   */
+  export interface ICustomServerClientRpc {}
+
+  /**
+   * Extend `alt.onRpc` and `alt.emitRpc` auto-completion by merging interfaces.
+   *
+   * @example
+   * ```ts
+   * declare module 'alt-client' {
+   *    interface ICustomClientServerRpc {
+   *        myRpc: (arg1: string, arg2: { key: string, value: number }): Promise<boolean>
+   *    }
+   * }
+   * ```
+   *
+   * @export
+   * @interface ICustomClientServerRpc
+   */
+  export interface ICustomClientServerRpc {}
+
   export interface IInspectOptions {
     /**
      * If set to `true`, getters are going to be


### PR DESCRIPTION
This change allows to extend the interfaces to gain autocomplete when using RPC's, also, change unknown for any to prevent TS to trow errors when dont using the autocompletion