### PR TITLE
Added `None` for `VehicleIndicatorLights`

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -52,6 +52,7 @@ declare module "alt-client" {
   }
 
   export const enum VehicleIndicatorLights {
+    None = 0,
     BlinkLeft = 1,
     BlinkRight = 2,
     BlinkPermBoth = 4,


### PR DESCRIPTION
Without this property, it is not possible to convert the code from TypeScript to JavaScript unless you suppress this warning with `@ts-ignore`
![image](https://github.com/altmp/altv-types/assets/139617589/154ec569-d639-4be5-b3cd-6195ef9bb6c6)
